### PR TITLE
Add "Remember me" button

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,17 +59,27 @@ Example usages:
 
 You can use a custom template for the password prompt - just copy `cli/password_template.html` and modify it to suit your presentation style and point to your template file with the `-f` flag. Be careful to not break the encrypting javascript part, the variables replaced by staticrypt are between curly brackets: `{instructions}`.
 
-**ADBLOCKERS**: If you do not embed crypto-js and serve it from a CDN, some adblockers see the `crypto-js.min.js`, think that's a crypto miner and block it.
+### `--remember`
+
+This will add a "Remember me" checkbox. If checked, when the user enters their passphrase its salted hashed value will be stored in localStorage. In case this value becomes compromised an attacker can decrypt the page, but this should hopefully protect against password reuse attack (of course please a unique passphrase nonetheless).
+
+This allows encrypting multiple page on a single domain with the same password: if you check "Remember me", you'll have to enter you password once then all the pages on that domain will automatically decrypt their content.
+
+If no value is provided the stored passphrase doesn't expire, you can also give it a value in days for how long should the store value be kept. If the user reconnects to the page after the expiration date the store value will be cleared.
+
+### `--embed` and crypto-js
+
+If you do not embed crypto-js and serve it from a CDN, some adblockers see the `crypto-js.min.js`, think that's a crypto miner and block it.
 
 ## Contribution
 
 Thank you: [@AaronCoplan](https://github.com/AaronCoplan) for bringing the CLI to life, [@epicfaace](https://github.com/epicfaace) & [@thomasmarr](https://github.com/thomasmarr) for sparking the caching of the passphrase in localStorage (allowing the "Remember me" checkbox)
 
-**Opening PRs:** You're free to open PRs if you're ok with having no response for a (very) long time and me ending up getting inspiration from your proposal but merging something different myself instead of your PR because of limited available time and lighter mental load (I'll try to credit you though). I still appreciate them but I'd rather be upfront about it, rather than waiting for a perfect occasion to manifest and never actually updating anything. Apologies in advance, and thank you!
+**Opening PRs:** You're free to open PRs if you're ok with having no response for a (possibly very) long time and me possibly ending up getting inspiration from your proposal but merging something different myself (I'll try to credit you though). Apologies in advance for the delay, and thank you!
 
 If you find a serious security bug please open an issue, I'll try to fix it relatively quickly.
 
-## Alternativs
+## Alternatives
 
 https://github.com/MaxLaumeister/PageCrypt is a similar project (I think it predates staticrypt).
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Staticrypt is available through npm as a CLI, install with `npm install -g stati
       -f, --file-template       Path to custom HTML template with password prompt.
                               [string] [default: "[...]/cli/password_template.html"]
       -r, --remember            Show a "Remember me" checkbox that will save the
-                                password in clear text in localStorage when
+                                (salted + hashed) passphrase in localStorage when
                                 entered by the user.
                                 You can set the expiration in days as value (no
                                 value means "0", no expiration).        [number]

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ This allows encrypting multiple page on a single domain with the same password: 
 
 If no value is provided the stored passphrase doesn't expire, you can also give it a value in days for how long should the store value be kept. If the user reconnects to the page after the expiration date the store value will be cleared.
 
+You can clear the values in localStorage (effectively "login out") at any time by appending `staticrypt_logout` to the URL query paramets (`mysite.com?staticrypt_logout`).
+
 ### `--embed` and crypto-js
 
 If you do not embed crypto-js and serve it from a CDN, some adblockers see the `crypto-js.min.js`, think that's a crypto miner and block it.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ Staticrypt is available through npm as a CLI, install with `npm install -g stati
                                                             [string] [default: null]
       -f, --file-template       Path to custom HTML template with password prompt.
                               [string] [default: "[...]/cli/password_template.html"]
+      -r, --remember            Show a "Remember me" checkbox that will save the
+                                password in clear text in localStorage when
+                                entered by the user.
+                                You can set the expiration in days as value (no
+                                value means "0", no expiration).        [number]
+      --remember-label          Label to use for the "Remember me" checkbox.
+                                Default: "Remember me".
+                                               [string] [default: "Remember me"]
+      --passphrase-placeholder  Placeholder to use for the passphrase input.
+                                Default: "Passphrase".
+                                                [string] [default: "Passphrase"]
+      --decrypt-button          Label to use for the decrypt button. Default:
+                                "DECRYPT".         [string] [default: "DECRYPT"]
 
 Example usages:
 
@@ -50,7 +63,7 @@ You can use a custom template for the password prompt - just copy `cli/password_
 
 ## Contribution
 
-Thank you: [@AaronCoplan](https://github.com/AaronCoplan) for bringing the CLI to life
+Thank you: [@AaronCoplan](https://github.com/AaronCoplan) for bringing the CLI to life, [@epicfaace](https://github.com/epicfaace) & [@thomasmarr](https://github.com/thomasmarr) for sparking the caching of the passphrase in localStorage (allowing the "Remember me" checkbox)
 
 **Opening PRs:** You're free to open PRs if you're ok with having no response for a (very) long time and me ending up getting inspiration from your proposal but merging something different myself instead of your PR because of limited available time and lighter mental load (I'll try to credit you though). I still appreciate them but I'd rather be upfront about it, rather than waiting for a perfect occasion to manifest and never actually updating anything. Apologies in advance, and thank you!
 
@@ -60,4 +73,4 @@ If you find a serious security bug please open an issue, I'll try to fix it rela
 
 https://github.com/MaxLaumeister/PageCrypt is a similar project (I think it predates staticrypt).
 
-https://github.com/tarpdalton/staticrypt/tree/webcrypto is a fork that uses the WebCrypto browser api to encrypt and decrypt the page, which removes the need for `crypto-js`. There's a PR open which I haven't checked in detail yet. WebCrypto is [only available in HTTPS context](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API) (which [is annoying people](https://github.com/w3c/webcrypto/issues/28)) so it won't work if you're on HTTP.
+https://github.com/tarpdalton/staticrypt/tree/webcrypto is a fork that uses the WebCrypto browser api to encrypt and decrypt the page, which removes the need for `crypto-js`. There's a PR open which I haven't checked in detail yet. WebCrypto is only available in HTTPS context (which [is annoying people](https://github.com/w3c/webcrypto/issues/28)) so it won't work if you're on HTTP.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You can use a custom template for the password prompt - just copy `cli/password_
 
 ### `--remember`
 
-This will add a "Remember me" checkbox. If checked, when the user enters their passphrase its salted hashed value will be stored in localStorage. In case this value becomes compromised an attacker can decrypt the page, but this should hopefully protect against password reuse attack (of course please a unique passphrase nonetheless).
+This will add a "Remember me" checkbox. If checked, when the user enters their passphrase its salted hashed value will be stored in localStorage. In case this value becomes compromised an attacker can decrypt the page, but this should hopefully protect against password reuse attack (of course please use a unique passphrase nonetheless).
 
 This allows encrypting multiple page on a single domain with the same password: if you check "Remember me", you'll have to enter you password once then all the pages on that domain will automatically decrypt their content.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -59,17 +59,27 @@ Example usages:
 
 You can use a custom template for the password prompt - just copy `cli/password_template.html` and modify it to suit your presentation style and point to your template file with the `-f` flag. Be careful to not break the encrypting javascript part, the variables replaced by staticrypt are between curly brackets: `{instructions}`.
 
-**ADBLOCKERS**: If you do not embed crypto-js and serve it from a CDN, some adblockers see the `crypto-js.min.js`, think that's a crypto miner and block it.
+### `--remember`
+
+This will add a "Remember me" checkbox. If checked, when the user enters their passphrase its salted hashed value will be stored in localStorage. In case this value becomes compromised an attacker can decrypt the page, but this should hopefully protect against password reuse attack (of course please a unique passphrase nonetheless).
+
+This allows encrypting multiple page on a single domain with the same password: if you check "Remember me", you'll have to enter you password once then all the pages on that domain will automatically decrypt their content.
+
+If no value is provided the stored passphrase doesn't expire, you can also give it a value in days for how long should the store value be kept. If the user reconnects to the page after the expiration date the store value will be cleared.
+
+### `--embed` and crypto-js
+
+If you do not embed crypto-js and serve it from a CDN, some adblockers see the `crypto-js.min.js`, think that's a crypto miner and block it.
 
 ## Contribution
 
 Thank you: [@AaronCoplan](https://github.com/AaronCoplan) for bringing the CLI to life, [@epicfaace](https://github.com/epicfaace) & [@thomasmarr](https://github.com/thomasmarr) for sparking the caching of the passphrase in localStorage (allowing the "Remember me" checkbox)
 
-**Opening PRs:** You're free to open PRs if you're ok with having no response for a (very) long time and me ending up getting inspiration from your proposal but merging something different myself instead of your PR because of limited available time and lighter mental load (I'll try to credit you though). I still appreciate them but I'd rather be upfront about it, rather than waiting for a perfect occasion to manifest and never actually updating anything. Apologies in advance, and thank you!
+**Opening PRs:** You're free to open PRs if you're ok with having no response for a (possibly very) long time and me possibly ending up getting inspiration from your proposal but merging something different myself (I'll try to credit you though). Apologies in advance for the delay, and thank you!
 
 If you find a serious security bug please open an issue, I'll try to fix it relatively quickly.
 
-## Alternativs
+## Alternatives
 
 https://github.com/MaxLaumeister/PageCrypt is a similar project (I think it predates staticrypt).
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -39,7 +39,7 @@ Staticrypt is available through npm as a CLI, install with `npm install -g stati
       -f, --file-template       Path to custom HTML template with password prompt.
                               [string] [default: "[...]/cli/password_template.html"]
       -r, --remember            Show a "Remember me" checkbox that will save the
-                                password in clear text in localStorage when
+                                (salted + hashed) passphrase in localStorage when
                                 entered by the user.
                                 You can set the expiration in days as value (no
                                 value means "0", no expiration).        [number]

--- a/cli/README.md
+++ b/cli/README.md
@@ -67,6 +67,8 @@ This allows encrypting multiple page on a single domain with the same password: 
 
 If no value is provided the stored passphrase doesn't expire, you can also give it a value in days for how long should the store value be kept. If the user reconnects to the page after the expiration date the store value will be cleared.
 
+You can clear the values in localStorage (effectively "login out") at any time by appending `staticrypt_logout` to the URL query paramets (`mysite.com?staticrypt_logout`).
+
 ### `--embed` and crypto-js
 
 If you do not embed crypto-js and serve it from a CDN, some adblockers see the `crypto-js.min.js`, think that's a crypto miner and block it.

--- a/cli/README.md
+++ b/cli/README.md
@@ -38,6 +38,19 @@ Staticrypt is available through npm as a CLI, install with `npm install -g stati
                                                             [string] [default: null]
       -f, --file-template       Path to custom HTML template with password prompt.
                               [string] [default: "[...]/cli/password_template.html"]
+      -r, --remember            Show a "Remember me" checkbox that will save the
+                                password in clear text in localStorage when
+                                entered by the user.
+                                You can set the expiration in days as value (no
+                                value means "0", no expiration).        [number]
+      --remember-label          Label to use for the "Remember me" checkbox.
+                                Default: "Remember me".
+                                               [string] [default: "Remember me"]
+      --passphrase-placeholder  Placeholder to use for the passphrase input.
+                                Default: "Passphrase".
+                                                [string] [default: "Passphrase"]
+      --decrypt-button          Label to use for the decrypt button. Default:
+                                "DECRYPT".         [string] [default: "DECRYPT"]
 
 Example usages:
 
@@ -50,7 +63,7 @@ You can use a custom template for the password prompt - just copy `cli/password_
 
 ## Contribution
 
-Thank you: [@AaronCoplan](https://github.com/AaronCoplan) for bringing the CLI to life
+Thank you: [@AaronCoplan](https://github.com/AaronCoplan) for bringing the CLI to life, [@epicfaace](https://github.com/epicfaace) & [@thomasmarr](https://github.com/thomasmarr) for sparking the caching of the passphrase in localStorage (allowing the "Remember me" checkbox)
 
 **Opening PRs:** You're free to open PRs if you're ok with having no response for a (very) long time and me ending up getting inspiration from your proposal but merging something different myself instead of your PR because of limited available time and lighter mental load (I'll try to credit you though). I still appreciate them but I'd rather be upfront about it, rather than waiting for a perfect occasion to manifest and never actually updating anything. Apologies in advance, and thank you!
 
@@ -60,4 +73,4 @@ If you find a serious security bug please open an issue, I'll try to fix it rela
 
 https://github.com/MaxLaumeister/PageCrypt is a similar project (I think it predates staticrypt).
 
-https://github.com/tarpdalton/staticrypt/tree/webcrypto is a fork that uses the WebCrypto browser api to encrypt and decrypt the page, which removes the need for `crypto-js`. There's a PR open which I haven't checked in detail yet. WebCrypto is [only available in HTTPS context](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API) (which [is annoying people](https://github.com/w3c/webcrypto/issues/28)) so it won't work if you're on HTTP.
+https://github.com/tarpdalton/staticrypt/tree/webcrypto is a fork that uses the WebCrypto browser api to encrypt and decrypt the page, which removes the need for `crypto-js`. There's a PR open which I haven't checked in detail yet. WebCrypto is only available in HTTPS context (which [is annoying people](https://github.com/w3c/webcrypto/issues/28)) so it won't work if you're on HTTP.

--- a/cli/README.md
+++ b/cli/README.md
@@ -61,7 +61,7 @@ You can use a custom template for the password prompt - just copy `cli/password_
 
 ### `--remember`
 
-This will add a "Remember me" checkbox. If checked, when the user enters their passphrase its salted hashed value will be stored in localStorage. In case this value becomes compromised an attacker can decrypt the page, but this should hopefully protect against password reuse attack (of course please a unique passphrase nonetheless).
+This will add a "Remember me" checkbox. If checked, when the user enters their passphrase its salted hashed value will be stored in localStorage. In case this value becomes compromised an attacker can decrypt the page, but this should hopefully protect against password reuse attack (of course please use a unique passphrase nonetheless).
 
 This allows encrypting multiple page on a single domain with the same password: if you check "Remember me", you'll have to enter you password once then all the pages on that domain will automatically decrypt their content.
 

--- a/cli/index.js
+++ b/cli/index.js
@@ -161,7 +161,7 @@ const hashedPassphrase = hashed.hashedPassphrase;
 const salt = hashed.salt;
 const encrypted = encrypt(contents, hashedPassphrase);
 // we use the hashed passphrase in the HMAC because this is effectively what will be used a passphrase (so we can store
-// it localStorage safely, we don't use the clear text passphrase)
+// it in localStorage safely, we don't use the clear text passphrase)
 const hmac = CryptoJS.HmacSHA256(encrypted, CryptoJS.SHA256(hashedPassphrase).toString()).toString();
 const encryptedMessage = hmac + encrypted;
 

--- a/cli/index.js
+++ b/cli/index.js
@@ -172,7 +172,7 @@ const data = {
     embed: namedArgs.embed,
     encrypted: encryptedMessage,
     instructions: namedArgs.instructions,
-    is_remember_enabled: isRememberEnabled,
+    is_remember_enabled: isRememberEnabled ? 'true' : 'false',
     output_file_path: namedArgs.output !== null ? namedArgs.output : input.replace(/\.html$/, '') + "_encrypted.html",
     passphrase_placeholder: namedArgs.passphrasePlaceholder,
     remember_duration_in_days: rememberDurationInDays,

--- a/cli/index.js
+++ b/cli/index.js
@@ -163,9 +163,6 @@ const encrypted = encrypt(contents, hashedPassphrase);
 // we use the hashed passphrase in the HMAC because this is effectively what will be used a passphrase (so we can store
 // it localStorage safely, we don't use the clear text passphrase)
 const hmac = CryptoJS.HmacSHA256(encrypted, CryptoJS.SHA256(hashedPassphrase).toString()).toString();
-console.log("encryptd passphrase", hashedPassphrase);
-console.log("hmac", hmac);
-console.log("salt", salt);
 const encryptedMessage = hmac + encrypted;
 
 // create crypto-js tag (embedded or not)

--- a/cli/index.js
+++ b/cli/index.js
@@ -10,125 +10,6 @@ const Yargs = require('yargs');
 const SCRIPT_URL = 'https://cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.9-1/crypto-js.min.js';
 const SCRIPT_TAG = '<script src="' + SCRIPT_URL + '" integrity="sha384-lp4k1VRKPU9eBnPePjnJ9M2RF3i7PC30gXs70+elCVfgwLwx1tv5+ctxdtwxqZa7" crossorigin="anonymous"></script>';
 
-const yargs = Yargs
-    .usage('Usage: staticrypt <filename> <passphrase> [options]')
-    .demandCommand(2)
-    .option('e', {
-        alias: 'embed',
-        type: 'boolean',
-        describe: 'Whether or not to embed crypto-js in the page (or use an external CDN).',
-        default: true
-    })
-    .option('o', {
-        alias: 'output',
-        type: 'string',
-        describe: 'File name / path for generated encrypted file.',
-        default: null
-    })
-    .option('t', {
-        alias: 'title',
-        type: 'string',
-        describe: "Title for output HTML page.",
-        default: 'Protected Page'
-    })
-    .option('i', {
-        alias: 'instructions',
-        type: 'string',
-        describe: 'Special instructions to display to the user.',
-        default: ''
-    })
-    .option('f', {
-        alias: 'file-template',
-        type: 'string',
-        describe: 'Path to custom HTML template with password prompt.',
-        default: path.join(__dirname, 'password_template.html')
-    })
-    // do not give a default option to this 'remember' parameter - we want to see when the flag is included with no
-    // value and when it's not included at all
-    .option('r', {
-        alias: 'remember',
-        type: 'number',
-        describe: 'Show a "Remember me" checkbox that will save the password in clear text in localStorage when entered by the user.\nYou can set the expiration in days as value (no value means "0", no expiration).',
-    })
-    .option('remember-label', {
-        type: 'string',
-        describe: 'Label to use for the "Remember me" checkbox. Default: "Remember me".',
-        default: 'Remember me'
-    })
-    .option('passphrase-placeholder', {
-        type: 'string',
-        describe: 'Placeholder to use for the passphrase input. Default: "Passphrase".',
-        default: 'Passphrase'
-    })
-    .option('decrypt-button', {
-        type: 'string',
-        describe: 'Label to use for the decrypt button. Default: "DECRYPT".',
-        default: 'DECRYPT'
-    });
-const namedArgs = yargs.argv;
-
-if (namedArgs._.length !== 2) {
-    Yargs.showHelp();
-    process.exit(1);
-}
-
-const input = namedArgs._[0].toString();
-const password = namedArgs._[1].toString();
-
-/**
- * Salt and encrypt a msg with a password.
- * Inspired by https://github.com/adonespitogo
- */
-function encrypt(msg, password) {
-    const keySize = 256;
-    const iterations = 1000;
-
-    const salt = CryptoJS.lib.WordArray.random(128 / 8);
-
-    const key = CryptoJS.PBKDF2(password, salt, {
-        keySize: keySize / 32,
-        iterations: iterations
-    });
-
-    const iv = CryptoJS.lib.WordArray.random(128 / 8);
-
-    const encrypted = CryptoJS.AES.encrypt(msg, key, {
-        iv: iv,
-        padding: CryptoJS.pad.Pkcs7,
-        mode: CryptoJS.mode.CBC
-    });
-
-    // salt, iv will be hex 32 in length
-    // append them to the ciphertext for use  in decryption
-    return salt.toString() + iv.toString() + encrypted.toString();
-}
-
-let contents;
-try {
-    contents = FileSystem.readFileSync(input, 'utf8');
-} catch (e) {
-    console.log("Failure: input file does not exist!");
-    process.exit(1);
-}
-
-// encrypt input
-const encrypted = encrypt(contents, password);
-const hmac = CryptoJS.HmacSHA256(encrypted, CryptoJS.SHA256(password).toString()).toString();
-const encryptedMessage = hmac + encrypted;
-
-// create crypto-js tag (embedded or not)
-let cryptoTag = SCRIPT_TAG;
-if (namedArgs.embed) {
-    try {
-        const embedContents = FileSystem.readFileSync(path.join(__dirname, 'crypto-js.min.js'), 'utf8');
-
-        cryptoTag = '<script>' + embedContents + '</script>';
-    } catch (e) {
-        console.log("Failure: embed file does not exist!");
-        process.exit(1);
-    }
-}
-
 /**
  * Check if a particular option has been set by the user. Use case:
  *
@@ -161,6 +42,145 @@ function userSetOption(option) {
     return false;
 }
 
+/**
+ * Salt and encrypt a msg with a password.
+ * Inspired by https://github.com/adonespitogo
+ */
+function encrypt(msg, hashedPassphrase) {
+    var iv = CryptoJS.lib.WordArray.random(128 / 8);
+
+    var encrypted = CryptoJS.AES.encrypt(msg, hashedPassphrase, {
+        iv: iv,
+        padding: CryptoJS.pad.Pkcs7,
+        mode: CryptoJS.mode.CBC
+    });
+
+    // iv will be hex 16 in length (32 characters)
+    // we prepend it to the ciphertext for use in decryption
+    return iv.toString() + encrypted.toString();
+}
+
+/**
+ * Salt and hash the passphrase so it can be stored in localStorage without opening a password reuse vulnerability.
+ *
+ * @param {string} passphrase
+ * @returns {{salt: string, hashedPassphrase: string}}
+ */
+function hashPassphrase(passphrase) {
+    var salt = CryptoJS.lib.WordArray.random(128 / 8).toString();
+
+    var hashedPassphrase = CryptoJS.PBKDF2(passphrase, salt, {
+        keySize: 256 / 32,
+        iterations: 1000
+    });
+
+    return {
+        salt: salt,
+        hashedPassphrase: hashedPassphrase.toString(),
+    };
+}
+
+const yargs = Yargs
+    .usage('Usage: staticrypt <filename> <passphrase> [options]')
+    .demandCommand(2)
+    .option('e', {
+        alias: 'embed',
+        type: 'boolean',
+        describe: 'Whether or not to embed crypto-js in the page (or use an external CDN).',
+        default: true
+    })
+    .option('o', {
+        alias: 'output',
+        type: 'string',
+        describe: 'File name / path for generated encrypted file.',
+        default: null
+    })
+    .option('t', {
+        alias: 'title',
+        type: 'string',
+        describe: "Title for output HTML page.",
+        default: 'Protected Page'
+    })
+    .option('i', {
+        alias: 'instructions',
+        type: 'string',
+        describe: 'Special instructions to display to the user.',
+        default: ''
+    })
+    .option('f', {
+        alias: 'file-template',
+        type: 'string',
+        describe: 'Path to custom HTML template with passphrase prompt.',
+        default: path.join(__dirname, 'password_template.html')
+    })
+    // do not give a default option to this 'remember' parameter - we want to see when the flag is included with no
+    // value and when it's not included at all
+    .option('r', {
+        alias: 'remember',
+        type: 'number',
+        describe: 'Show a "Remember me" checkbox that will save the passphrase in clear text in localStorage when entered by the user.\nYou can set the expiration in days as value (no value means "0", no expiration).',
+    })
+    .option('remember-label', {
+        type: 'string',
+        describe: 'Label to use for the "Remember me" checkbox. Default: "Remember me".',
+        default: 'Remember me'
+    })
+    .option('passphrase-placeholder', {
+        type: 'string',
+        describe: 'Placeholder to use for the passphrase input. Default: "Passphrase".',
+        default: 'Passphrase'
+    })
+    .option('decrypt-button', {
+        type: 'string',
+        describe: 'Label to use for the decrypt button. Default: "DECRYPT".',
+        default: 'DECRYPT'
+    });
+const namedArgs = yargs.argv;
+
+if (namedArgs._.length !== 2) {
+    Yargs.showHelp();
+    process.exit(1);
+}
+
+// parse input
+const input = namedArgs._[0].toString(),
+    passphrase = namedArgs._[1].toString();
+
+// get the file content
+let contents;
+try {
+    contents = FileSystem.readFileSync(input, 'utf8');
+} catch (e) {
+    console.log("Failure: input file does not exist!");
+    process.exit(1);
+}
+
+// encrypt input
+const hashed = hashPassphrase(passphrase);
+const hashedPassphrase = hashed.hashedPassphrase;
+const salt = hashed.salt;
+const encrypted = encrypt(contents, hashedPassphrase);
+// we use the hashed passphrase in the HMAC because this is effectively what will be used a passphrase (so we can store
+// it localStorage safely, we don't use the clear text passphrase)
+const hmac = CryptoJS.HmacSHA256(encrypted, CryptoJS.SHA256(hashedPassphrase).toString()).toString();
+console.log("encryptd passphrase", hashedPassphrase);
+console.log("hmac", hmac);
+console.log("salt", salt);
+const encryptedMessage = hmac + encrypted;
+
+// create crypto-js tag (embedded or not)
+let cryptoTag = SCRIPT_TAG;
+if (namedArgs.embed) {
+    try {
+        const embedContents = FileSystem.readFileSync(path.join(__dirname, 'crypto-js.min.js'), 'utf8');
+
+        cryptoTag = '<script>' + embedContents + '</script>';
+    } catch (e) {
+        console.log("Failure: embed file does not exist!");
+        process.exit(1);
+    }
+}
+
 const isRememberEnabled = userSetOption('r');
 // give a default value here instead of in the yargs config, so we can distinguish when the flag is included with no
 // value from when the flag isn't included
@@ -177,6 +197,7 @@ const data = {
     passphrase_placeholder: namedArgs.passphrasePlaceholder,
     remember_duration_in_days: rememberDurationInDays,
     remember_me: namedArgs.rememberLabel,
+    salt: salt,
     title: namedArgs.title,
 };
 

--- a/cli/index.js
+++ b/cli/index.js
@@ -130,7 +130,7 @@ if (namedArgs.embed) {
 }
 
 /**
- * Check if a particular option has been set by the user. User case:
+ * Check if a particular option has been set by the user. Use case:
  *
  * // The "--remember" flag has a specific behavior: if the flag is included without value (like '-r'), the key is set with
  * // the value 'undefined'. If it is included with a value, ('-r 100'), the key is set with that value. Both means

--- a/cli/index.js
+++ b/cli/index.js
@@ -11,41 +11,63 @@ const SCRIPT_URL = 'https://cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.9-1/cry
 const SCRIPT_TAG = '<script src="' + SCRIPT_URL + '" integrity="sha384-lp4k1VRKPU9eBnPePjnJ9M2RF3i7PC30gXs70+elCVfgwLwx1tv5+ctxdtwxqZa7" crossorigin="anonymous"></script>';
 
 const namedArgs = Yargs
-      .usage('Usage: staticrypt <filename> <passphrase> [options]')
-      .demandCommand(2)
-      .option('e', {
-          alias: 'embed',
-          type: 'boolean',
-          describe: 'Whether or not to embed crypto-js in the page (or use an external CDN)',
-          default: true
-      })
-      .option('o', {
-          alias: 'output',
-          type: 'string',
-          describe: 'File name / path for generated encrypted file',
-          default: null
-      })
-      .option('t', {
-          alias: 'title',
-          type: 'string',
-          describe: "Title for output HTML page",
-          default: 'Protected Page'
-      })
-      .option('i', {
-          alias: 'instructions',
-          type: 'string',
-          describe: 'Special instructions to display to the user.',
-          default: ''
-      })
-      .option('f', {
-          alias: 'file-template',
-          type: 'string',
-          describe: 'Path to custom HTML template with password prompt.',
-          default: path.join(__dirname, 'password_template.html')
-      })
-      .argv;
+    .usage('Usage: staticrypt <filename> <passphrase> [options]')
+    .demandCommand(2)
+    .option('e', {
+        alias: 'embed',
+        type: 'boolean',
+        describe: 'Whether or not to embed crypto-js in the page (or use an external CDN).',
+        default: true
+    })
+    .option('o', {
+        alias: 'output',
+        type: 'string',
+        describe: 'File name / path for generated encrypted file.',
+        default: null
+    })
+    .option('t', {
+        alias: 'title',
+        type: 'string',
+        describe: "Title for output HTML page.",
+        default: 'Protected Page'
+    })
+    .option('i', {
+        alias: 'instructions',
+        type: 'string',
+        describe: 'Special instructions to display to the user.',
+        default: ''
+    })
+    .option('f', {
+        alias: 'file-template',
+        type: 'string',
+        describe: 'Path to custom HTML template with password prompt.',
+        default: path.join(__dirname, 'password_template.html')
+    })
+    // do not give a default option to this 'remember' parameter - we want to see when the flag is included with no
+    // value and when it's not included at all
+    .option('r', {
+        alias: 'remember',
+        type: 'number',
+        describe: 'Show a "Remember me" checkbox that will save the password in clear text in localStorage when entered by the user.\nYou can set the expiration in days as value (no value means "0", no expiration).',
+    })
+    .option('remember-label', {
+        type: 'string',
+        describe: 'Label to use for the "Remember me" checkbox. Default: "Remember me".',
+        default: 'Remember me'
+    })
+    .option('passphrase-placeholder', {
+        type: 'string',
+        describe: 'Placeholder to use for the passphrase input. Default: "Passphrase".',
+        default: 'Passphrase'
+    })
+    .option('decrypt-button', {
+        type: 'string',
+        describe: 'Label to use for the decrypt button. Default: "DECRYPT".',
+        default: 'DECRYPT'
+    })
+    .argv;
 
-if(namedArgs._.length !== 2){
+if (namedArgs._.length !== 2) {
     Yargs.showHelp();
     process.exit(1);
 }
@@ -53,9 +75,9 @@ if(namedArgs._.length !== 2){
 const input = namedArgs._[0].toString();
 const password = namedArgs._[1].toString();
 
-try{
+try {
     var contents = FileSystem.readFileSync(input, 'utf8');
-}catch(e){
+} catch (e) {
     console.log("Failure: input file does not exist!");
     process.exit(1);
 }
@@ -66,15 +88,16 @@ try{
  */
 var keySize = 256;
 var iterations = 1000;
-function encrypt (msg, password) {
-    var salt = CryptoJS.lib.WordArray.random(128/8);
+
+function encrypt(msg, password) {
+    var salt = CryptoJS.lib.WordArray.random(128 / 8);
 
     var key = CryptoJS.PBKDF2(password, salt, {
-        keySize: keySize/32,
+        keySize: keySize / 32,
         iterations: iterations
     });
 
-    var iv = CryptoJS.lib.WordArray.random(128/8);
+    var iv = CryptoJS.lib.WordArray.random(128 / 8);
 
     var encrypted = CryptoJS.AES.encrypt(msg, key, {
         iv: iv,
@@ -84,8 +107,7 @@ function encrypt (msg, password) {
 
     // salt, iv will be hex 32 in length
     // append them to the ciphertext for use  in decryption
-    var encryptedMsg = salt.toString()+ iv.toString() + encrypted.toString();
-    return encryptedMsg;
+    return salt.toString() + iv.toString() + encrypted.toString();
 }
 
 // encrypt input
@@ -98,21 +120,34 @@ var cryptoTag = SCRIPT_TAG;
 if (namedArgs.embed) {
     try {
         var embedContents = FileSystem.readFileSync(path.join(__dirname, 'crypto-js.min.js'), 'utf8');
-    } catch(e) {
+    } catch (e) {
         console.log("Failure: embed file does not exist!");
         process.exit(1);
     }
     cryptoTag = '<script>' + embedContents + '</script>';
 }
 
+console.log(JSON.stringify(namedArgs, null, 2))
+
+// The "--remember" flag has a specific behavior: if the flag is included without value (like '-r'), the key is set with
+// the value 'undefined'. If it is included with a value, ('-r 100'), the key is set with that value. Both means
+// remember is enabled. If the flag is omitted by the user the key isn't set, meaning remember is disabled.
+const isRememberEnabled = 'remember' in namedArgs;
+// give a default value here instead of in the yargs config, so we can distinguish when the flag is included with no
+// value from when the flag isn't included
+const rememberDurationInDays = namedArgs.remember || 0;
 
 var data = {
-    title: namedArgs.title,
-    instructions: namedArgs.instructions,
-    encrypted: encryptedMessage,
     crypto_tag: cryptoTag,
     embed: namedArgs.embed,
-    outputFilePath: namedArgs.output !== null ? namedArgs.output : input.replace(/\.html$/, '') + "_encrypted.html"
+    encrypted: encryptedMessage,
+    instructions: namedArgs.instructions,
+    is_remember_enabled: isRememberEnabled,
+    output_file_path: namedArgs.output !== null ? namedArgs.output : input.replace(/\.html$/, '') + "_encrypted.html",
+    passphrase_placeholder: namedArgs["passphrase-placeholder"],
+    remember_duration_in_days: rememberDurationInDays,
+    remember_me: namedArgs["remember-label"],
+    title: namedArgs.title,
 };
 
 genFile(data);
@@ -123,19 +158,19 @@ genFile(data);
  *
  * @param data
  */
-function genFile(data){
-    try{
+function genFile(data) {
+    try {
         var templateContents = FileSystem.readFileSync(namedArgs.f, 'utf8');
-    }catch(e){
+    } catch (e) {
         console.log("Failure: could not read template!");
         process.exit(1);
     }
 
     var renderedTemplate = render(templateContents, data);
 
-    try{
-        FileSystem.writeFileSync(data.outputFilePath, renderedTemplate);
-    }catch(e){
+    try {
+        FileSystem.writeFileSync(data.output_file_path, renderedTemplate);
+    } catch (e) {
         console.log("Failure: could not generate output file!");
         process.exit(1);
     }
@@ -148,7 +183,7 @@ function genFile(data){
  * @param data
  * @returns string
  */
-function render(tpl, data){
+function render(tpl, data) {
     return tpl.replace(/{(.*?)}/g, function (_, key) {
         return data && data[key] || '';
     });

--- a/cli/index.js
+++ b/cli/index.js
@@ -118,7 +118,7 @@ const yargs = Yargs
     .option('r', {
         alias: 'remember',
         type: 'number',
-        describe: 'Show a "Remember me" checkbox that will save the passphrase in clear text in localStorage when entered by the user.\nYou can set the expiration in days as value (no value means "0", no expiration).',
+        describe: 'Show a "Remember me" checkbox that will save the (salted + hashed) passphrase in localStorage when entered by the user.\nYou can set the expiration in days as value (no value means "0", no expiration).',
     })
     .option('remember-label', {
         type: 'string',

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,361 +1,304 @@
 {
-    "name": "staticrypt-cli",
-    "version": "1.2.0",
-    "lockfileVersion": 1,
-    "requires": true,
-    "dependencies": {
-        "ansi-regex": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "camelcase": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-            "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-        },
-        "cliui": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-            "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-            "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wrap-ansi": "2.1.0"
-            },
-            "dependencies": {
-                "string-width": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                    "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
-                    }
-                }
-            }
-        },
-        "code-point-at": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-        },
-        "cross-spawn": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-            "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-            "requires": {
-                "lru-cache": "4.1.1",
-                "shebang-command": "1.2.0",
-                "which": "1.3.0"
-            }
-        },
-        "crypto-js": {
-            "version": "3.1.9-1",
-            "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
-            "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
-        },
-        "decamelize": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
-        },
-        "execa": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-            "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-            "requires": {
-                "cross-spawn": "5.1.0",
-                "get-stream": "3.0.0",
-                "is-stream": "1.1.0",
-                "npm-run-path": "2.0.2",
-                "p-finally": "1.0.0",
-                "signal-exit": "3.0.2",
-                "strip-eof": "1.0.0"
-            }
-        },
-        "find-up": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-            "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-            "requires": {
-                "locate-path": "2.0.0"
-            }
-        },
-        "get-caller-file": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-            "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
-        },
-        "get-stream": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-        },
-        "invert-kv": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-        },
-        "is-fullwidth-code-point": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-            "requires": {
-                "number-is-nan": "1.0.1"
-            }
-        },
-        "is-stream": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-        },
-        "isexe": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-        },
-        "lcid": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-            "requires": {
-                "invert-kv": "1.0.0"
-            }
-        },
-        "locate-path": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-            "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-            "requires": {
-                "p-locate": "2.0.0",
-                "path-exists": "3.0.0"
-            }
-        },
-        "lru-cache": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-            "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-            "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
-            }
-        },
-        "mem": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-            "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-            "requires": {
-                "mimic-fn": "1.1.0"
-            }
-        },
-        "mimic-fn": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-            "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
-        },
-        "npm-run-path": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-            "requires": {
-                "path-key": "2.0.1"
-            }
-        },
-        "number-is-nan": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-        },
-        "os-locale": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-            "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-            "requires": {
-                "execa": "0.7.0",
-                "lcid": "1.0.0",
-                "mem": "1.1.0"
-            }
-        },
-        "p-finally": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-        },
-        "p-limit": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-            "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
-        },
-        "p-locate": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-            "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-            "requires": {
-                "p-limit": "1.1.0"
-            }
-        },
-        "path-exists": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-        },
-        "path-key": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
-        },
-        "pseudomap": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-        },
-        "require-directory": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-        },
-        "require-main-filename": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
-        },
-        "set-blocking": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-        },
-        "shebang-command": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-            "requires": {
-                "shebang-regex": "1.0.0"
-            }
-        },
-        "shebang-regex": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-        },
-        "signal-exit": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-        },
-        "string-width": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-            "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-                },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-                },
-                "strip-ansi": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                    "requires": {
-                        "ansi-regex": "3.0.0"
-                    }
-                }
-            }
-        },
-        "strip-ansi": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-            "requires": {
-                "ansi-regex": "2.1.1"
-            }
-        },
-        "strip-eof": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
-        },
-        "which": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-            "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-            "requires": {
-                "isexe": "2.0.0"
-            }
-        },
-        "which-module": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-        },
-        "wrap-ansi": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-            "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1"
-            },
-            "dependencies": {
-                "string-width": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                    "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
-                    }
-                }
-            }
-        },
-        "y18n": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-        },
-        "yallist": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-        },
-        "yargs": {
-            "version": "10.0.3",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
-            "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
-            "requires": {
-                "cliui": "3.2.0",
-                "decamelize": "1.2.0",
-                "find-up": "2.1.0",
-                "get-caller-file": "1.0.2",
-                "os-locale": "2.1.0",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "2.1.1",
-                "which-module": "2.0.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "8.1.0"
-            }
-        },
-        "yargs-parser": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-            "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
-            "requires": {
-                "camelcase": "4.1.0"
-            }
-        }
+  "name": "staticrypt",
+  "version": "1.3.2",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "staticrypt",
+      "version": "1.3.2",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-js": ">=3.1.9-1",
+        "yargs": ">=10.0.3"
+      },
+      "bin": {
+        "staticrypt": "index.js"
+      },
+      "devDependencies": {}
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/crypto-js": {
+      "version": "3.1.9-1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
+      "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+      "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
+      "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+      "engines": {
+        "node": ">=12"
+      }
     }
+  },
+  "dependencies": {
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "crypto-js": {
+      "version": "3.1.9-1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
+      "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+    },
+    "yargs": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+      "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.0.0"
+      }
+    },
+    "yargs-parser": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
+      "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA=="
+    }
+  }
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -34,5 +34,5 @@
   "bugs": {
     "url": "https://github.com/robinmoisson/staticrypt/issues"
   },
-  "homepage": "https://github.com/robinmoisson/staticrypt#readme"
+  "homepage": "https://github.com/robinmoisson/staticrypt"
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "staticrypt",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Based on the [crypto-js](https://github.com/brix/crypto-js) library, StatiCrypt uses AES-256 to encrypt your input with your passphrase and put it in a HTML file with a password prompt that can decrypted in-browser (client side).",
   "main": "index.js",
   "bin": {

--- a/cli/password_template.html
+++ b/cli/password_template.html
@@ -38,7 +38,7 @@
             box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.2), 0 5px 5px 0 rgba(0, 0, 0, 0.24);
         }
 
-        .staticrypt-form input {
+        .staticrypt-form input[type="password"] {
             outline: 0;
             background: #f2f2f2;
             width: 100%;
@@ -110,6 +110,21 @@
         .staticrypt-footer a {
             text-decoration: none;
         }
+
+        label.staticrypt-remember {
+            display: flex;
+            align-items: center;
+            margin-bottom: 1em;
+        }
+
+        .staticrypt-remember input[type=checkbox] {
+            transform: scale(1.5);
+            margin-right: 1em;
+        }
+
+        .hidden {
+            display: none !important;
+        }
     </style>
 </head>
 
@@ -127,10 +142,17 @@
             <input id="staticrypt-password"
                    type="password"
                    name="password"
-                   placeholder="passphrase"
+                   placeholder="{passphrase_placeholder}"
                    autofocus/>
 
-            <input type="submit" class="staticrypt-decrypt-button" value="DECRYPT"/>
+            <label id="staticrypt-remember-label" class="staticrypt-remember hidden">
+                <input id="staticrypt-remember"
+                       type="checkbox"
+                       name="remember"/>
+                {remember_me}
+            </label>
+
+            <input type="submit" class="staticrypt-decrypt-button" value="{decrypt_button}"/>
         </form>
     </div>
 
@@ -143,48 +165,138 @@
 {crypto_tag}
 
 <script>
+    // variables to be filled when generating the file
+    var encryptedMsg = '{encrypted}',
+        isRememberEnabled = {is_remember_enabled},
+        rememberDurationInDays = {remember_duration_in_days}; // 0 means forever
+
+    // constants
+    var rememberPassphraseKey = 'staticrypt-passphrase',
+        rememberExpirationKey = 'staticrypt-expiration';
+
     /**
      * Decrypt a salted msg using a password.
      * Inspired by https://github.com/adonespitogo
+     *
+     * @param {string} encryptedMsg
+     * @param {string} pass
+     * @returns {string}
      */
-    var keySize = 256;
-    var iterations = 1000;
-    function decrypt (encryptedMsg, pass) {
+    function decryptMsg(encryptedMsg, pass) {
+        var keySize = 256;
+        var iterations = 1000;
+
         var salt = CryptoJS.enc.Hex.parse(encryptedMsg.substr(0, 32));
         var iv = CryptoJS.enc.Hex.parse(encryptedMsg.substr(32, 32))
         var encrypted = encryptedMsg.substring(64);
 
         var key = CryptoJS.PBKDF2(pass, salt, {
-            keySize: keySize/32,
+            keySize: keySize / 32,
             iterations: iterations
         });
 
-        var decrypted = CryptoJS.AES.decrypt(encrypted, key, {
+        return CryptoJS.AES.decrypt(encrypted, key, {
             iv: iv,
             padding: CryptoJS.pad.Pkcs7,
             mode: CryptoJS.mode.CBC
         }).toString(CryptoJS.enc.Utf8);
-        return decrypted;
     }
 
-    document.getElementById('staticrypt-form').addEventListener('submit', function(e) {
-        e.preventDefault();
-
-        var passphrase = document.getElementById('staticrypt-password').value,
-            encryptedMsg = '{encrypted}',
-            encryptedHMAC = encryptedMsg.substring(0, 64),
+    /**
+     * Decrypt our encrypted page, replace the whole HTML.
+     *
+     * @param passphrase
+     * @returns {boolean}
+     */
+    function decryptAndReplaceHtml(passphrase) {
+        var encryptedHMAC = encryptedMsg.substring(0, 64),
             encryptedHTML = encryptedMsg.substring(64),
             decryptedHMAC = CryptoJS.HmacSHA256(encryptedHTML, CryptoJS.SHA256(passphrase).toString()).toString();
 
         if (decryptedHMAC !== encryptedHMAC) {
-            alert('Bad passphrase!');
-            return;
+            return false;
         }
 
-        var plainHTML = decrypt(encryptedHTML, passphrase);
+        var plainHTML = decryptMsg(encryptedHTML, passphrase);
 
         document.write(plainHTML);
         document.close();
+
+        return true;
+    }
+
+    /**
+     * Clear localstorage from staticrypt related values
+     */
+    function clearLocalStorage() {
+        localStorage.removeItem(rememberPassphraseKey);
+        localStorage.removeItem(rememberExpirationKey);
+    }
+
+    // try to automatically decrypt on load if there is a saved password
+    window.onload = function () {
+        if (isRememberEnabled) {
+            // show the remember me checkbox
+            document.getElementById('staticrypt-remember-label').classList.remove('hidden');
+
+            // if we are login out, clear the storage and terminate
+            var queryParams = new URLSearchParams(window.location.search);
+
+            if (queryParams.has("staticrypt_logout")) {
+                return clearLocalStorage();
+            }
+
+            // if there is expiration configured, if we're not beyond the expiration
+            if (rememberDurationInDays && rememberDurationInDays > 0) {
+                var expiration = localStorage.getItem(rememberExpirationKey),
+                    isExpired = expiration && new Date().getTime() > parseInt(expiration);
+
+                if (isExpired) {
+                    return clearLocalStorage();
+                }
+            }
+
+            var passphrase = localStorage.getItem(rememberPassphraseKey);
+
+            if (passphrase) {
+                // try to decrypt
+                var isDecryptionSuccessful = decryptAndReplaceHtml(passphrase);
+
+                // if the decryption is unsuccessful the password might be wrong - silently clear the saved data and let
+                // the user fill the password form again
+                if (!isDecryptionSuccessful) {
+                    return clearLocalStorage();
+                }
+            }
+        }
+    }
+
+    // handle password form submission
+    document.getElementById('staticrypt-form').addEventListener('submit', function (e) {
+        e.preventDefault();
+
+        var passphrase = document.getElementById('staticrypt-password').value,
+            shouldRememberPassphrase = document.getElementById('staticrypt-remember').checked;
+
+        // decrypt and replace the whole page
+        var isDecryptionSuccessful = decryptAndReplaceHtml(passphrase);
+
+        if (isDecryptionSuccessful) {
+            // remember the passphrase and set its expiration if necessary
+            if (isRememberEnabled && shouldRememberPassphrase) {
+                window.localStorage.setItem(rememberPassphraseKey, passphrase);
+
+                // set the expiration if the duration isn't 0 (meaning no expiration)
+                if (rememberDurationInDays > 0) {
+                    window.localStorage.setItem(
+                        rememberExpirationKey,
+                        (new Date().getTime() + rememberDurationInDays * 24 * 60 * 60 * 1000).toString()
+                    );
+                }
+            }
+        } else {
+            alert('Bad passphrase!');
+        }
     });
 </script>
 </body>

--- a/cli/password_template.html
+++ b/cli/password_template.html
@@ -167,35 +167,27 @@
 <script>
     // variables to be filled when generating the file
     var encryptedMsg = '{encrypted}',
+        salt = '{salt}',
         isRememberEnabled = {is_remember_enabled},
         rememberDurationInDays = {remember_duration_in_days}; // 0 means forever
 
     // constants
-    var rememberPassphraseKey = 'staticrypt-passphrase',
-        rememberExpirationKey = 'staticrypt-expiration';
+    var rememberPassphraseKey = 'staticrypt_passphrase',
+        rememberExpirationKey = 'staticrypt_expiration';
 
     /**
      * Decrypt a salted msg using a password.
      * Inspired by https://github.com/adonespitogo
      *
      * @param {string} encryptedMsg
-     * @param {string} pass
+     * @param {string} hashedPassphrase
      * @returns {string}
      */
-    function decryptMsg(encryptedMsg, pass) {
-        var keySize = 256;
-        var iterations = 1000;
+    function decryptMsg(encryptedMsg, hashedPassphrase) {
+        var iv = CryptoJS.enc.Hex.parse(encryptedMsg.substr(0, 32))
+        var encrypted = encryptedMsg.substring(32);
 
-        var salt = CryptoJS.enc.Hex.parse(encryptedMsg.substr(0, 32));
-        var iv = CryptoJS.enc.Hex.parse(encryptedMsg.substr(32, 32))
-        var encrypted = encryptedMsg.substring(64);
-
-        var key = CryptoJS.PBKDF2(pass, salt, {
-            keySize: keySize / 32,
-            iterations: iterations
-        });
-
-        return CryptoJS.AES.decrypt(encrypted, key, {
+        return CryptoJS.AES.decrypt(encrypted, hashedPassphrase, {
             iv: iv,
             padding: CryptoJS.pad.Pkcs7,
             mode: CryptoJS.mode.CBC
@@ -205,24 +197,37 @@
     /**
      * Decrypt our encrypted page, replace the whole HTML.
      *
-     * @param passphrase
+     * @param {string} hashedPassphrase
      * @returns {boolean}
      */
-    function decryptAndReplaceHtml(passphrase) {
+    function decryptAndReplaceHtml(hashedPassphrase) {
         var encryptedHMAC = encryptedMsg.substring(0, 64),
             encryptedHTML = encryptedMsg.substring(64),
-            decryptedHMAC = CryptoJS.HmacSHA256(encryptedHTML, CryptoJS.SHA256(passphrase).toString()).toString();
+            decryptedHMAC = CryptoJS.HmacSHA256(encryptedHTML, CryptoJS.SHA256(hashedPassphrase).toString()).toString();
 
         if (decryptedHMAC !== encryptedHMAC) {
             return false;
         }
 
-        var plainHTML = decryptMsg(encryptedHTML, passphrase);
+        var plainHTML = decryptMsg(encryptedHTML, hashedPassphrase);
 
         document.write(plainHTML);
         document.close();
 
         return true;
+    }
+
+    /**
+     * Salt and hash the passphrase so it can be stored in localStorage without opening a password reuse vulnerability.
+     *
+     * @param {string} passphrase
+     * @returns {string}
+     */
+    function hashPassphrase(passphrase) {
+        return CryptoJS.PBKDF2(passphrase, salt, {
+            keySize: 256 / 32,
+            iterations: 1000
+        }).toString();
     }
 
     /**
@@ -246,7 +251,7 @@
                 return clearLocalStorage();
             }
 
-            // if there is expiration configured, if we're not beyond the expiration
+            // if there is expiration configured, check if we're not beyond the expiration
             if (rememberDurationInDays && rememberDurationInDays > 0) {
                 var expiration = localStorage.getItem(rememberExpirationKey),
                     isExpired = expiration && new Date().getTime() > parseInt(expiration);
@@ -256,11 +261,11 @@
                 }
             }
 
-            var passphrase = localStorage.getItem(rememberPassphraseKey);
+            var hashedPassphrase = localStorage.getItem(rememberPassphraseKey);
 
-            if (passphrase) {
+            if (hashedPassphrase) {
                 // try to decrypt
-                var isDecryptionSuccessful = decryptAndReplaceHtml(passphrase);
+                var isDecryptionSuccessful = decryptAndReplaceHtml(hashedPassphrase);
 
                 // if the decryption is unsuccessful the password might be wrong - silently clear the saved data and let
                 // the user fill the password form again
@@ -279,12 +284,13 @@
             shouldRememberPassphrase = document.getElementById('staticrypt-remember').checked;
 
         // decrypt and replace the whole page
-        var isDecryptionSuccessful = decryptAndReplaceHtml(passphrase);
+        var hashedPassphrase = hashPassphrase(passphrase);
+        var isDecryptionSuccessful = decryptAndReplaceHtml(hashedPassphrase);
 
         if (isDecryptionSuccessful) {
-            // remember the passphrase and set its expiration if necessary
+            // remember the hashedPassphrase and set its expiration if necessary
             if (isRememberEnabled && shouldRememberPassphrase) {
-                window.localStorage.setItem(rememberPassphraseKey, passphrase);
+                window.localStorage.setItem(rememberPassphraseKey, hashedPassphrase);
 
                 // set the expiration if the duration isn't 0 (meaning no expiration)
                 if (rememberDurationInDays > 0) {

--- a/index.html
+++ b/index.html
@@ -220,7 +220,11 @@ Filename changed to circumvent adblockers that mistake it for a crypto miner (se
 
     var renderTemplate = function (tpl, data) {
         return tpl.replace(/{(.*?)}/g, function (_, key) {
-            return data && data[key] || '';
+            if (data && data[key] !== undefined) {
+                return data[key];
+            }
+
+            return '';
         });
     };
 

--- a/index.html
+++ b/index.html
@@ -316,11 +316,12 @@ Filename changed to circumvent adblockers that mistake it for a crypto miner (se
             passphrase = document.getElementById('passphrase').value;
 
         var hashed = hashPassphrase(passphrase);
-        // we actually use the hashedPassphrase as the encryption passphrase
         var hashedPassphrase = hashed.hashedPassphrase,
             salt = hashed.salt;
 
         var encrypted = encrypt(unencrypted, hashedPassphrase),
+            // we use the hashed passphrase in the HMAC because this is effectively what will be used a passphrase (so
+            // we can store it localStorage safely, we don't use the clear text passphrase)
             hmac = CryptoJS.HmacSHA256(encrypted, CryptoJS.SHA256(hashedPassphrase).toString()).toString(),
             encryptedMsg = hmac + encrypted;
 
@@ -345,7 +346,7 @@ Filename changed to circumvent adblockers that mistake it for a crypto miner (se
             title: pageTitle ? pageTitle : 'Protected Page',
         };
 
-        document.getElementById('encrypted_html_display').textContent = encryptedMsg;
+        document.getElementById('encrypted_html_display').textContent = encrypted;
 
         if (document.getElementById("embed-crypto").checked) {
             setFileToDownloadWithEmbeddedCrypto(data);

--- a/index.html
+++ b/index.html
@@ -147,7 +147,8 @@
 
                     <div class="form-group">
                         <label for="title">Passphrase input placeholder</label>
-                        <input type="text" class="form-control" id="passphrase_placeholder" placeholder="Default: 'Passphrase'">
+                        <input type="text" class="form-control" id="passphrase_placeholder"
+                               placeholder="Default: 'Passphrase'">
                     </div>
 
                     <div class="form-group">
@@ -163,7 +164,8 @@
                                step="any"
                                placeholder="Default: 0 (no expiration)">
                         <small class="form-text text-muted">
-                            After this many days, the user will have to enter the passphrase again. Leave empty or set to 0 for no expiration.
+                            After this many days, the user will have to enter the passphrase again. Leave empty or set
+                            to 0 for no expiration.
                         </small>
                     </div>
 
@@ -177,7 +179,8 @@
                             <input type="checkbox" id="embed-crypto" checked>
                             Embed crypto-js into your file
                             <small>
-                                <abbr class="text-muted" title="Leave checked to include crypto-js into your file so you can decrypt it offline. Uncheck to load crypto-js from a CDN (some adblockers might think it's a crypto miner).">
+                                <abbr class="text-muted"
+                                      title="Leave checked to include crypto-js into your file so you can decrypt it offline. Uncheck to load crypto-js from a CDN (some adblockers might think it's a crypto miner).">
                                     (?)
                                 </abbr>
                             </small>
@@ -265,28 +268,38 @@ Filename changed to circumvent adblockers that mistake it for a crypto miner (se
      * Salt and encrypt a msg with a password.
      * Inspired by https://github.com/adonespitogo
      */
-    function encrypt(msg, password) {
-        var keySize = 256;
-        var iterations = 1000;
-
-        var salt = CryptoJS.lib.WordArray.random(128 / 8);
-
-        var key = CryptoJS.PBKDF2(password, salt, {
-            keySize: keySize / 32,
-            iterations: iterations
-        });
-
+    function encrypt(msg, hashedPassphrase) {
         var iv = CryptoJS.lib.WordArray.random(128 / 8);
 
-        var encrypted = CryptoJS.AES.encrypt(msg, key, {
+        var encrypted = CryptoJS.AES.encrypt(msg, hashedPassphrase, {
             iv: iv,
             padding: CryptoJS.pad.Pkcs7,
             mode: CryptoJS.mode.CBC
         });
 
-        // salt, iv will be hex 32 in length
-        // append them to the ciphertext for use  in decryption
-        return salt.toString() + iv.toString() + encrypted.toString();
+        // iv will be hex 16 in length (32 characters)
+        // we prepend it to the ciphertext for use in decryption
+        return iv.toString() + encrypted.toString();
+    }
+
+    /**
+     * Salt and hash the passphrase so it can be stored in localStorage without opening a password reuse vulnerability.
+     *
+     * @param {string} passphrase
+     * @returns {{salt: string, hashedPassphrase: string}}
+     */
+    function hashPassphrase(passphrase) {
+        var salt = CryptoJS.lib.WordArray.random(128 / 8).toString();
+
+        var hashedPassphrase = CryptoJS.PBKDF2(passphrase, salt, {
+            keySize: 256 / 32,
+            iterations: 1000
+        });
+
+        return {
+            salt: salt,
+            hashedPassphrase: hashedPassphrase.toString(),
+        };
     }
 
     /**
@@ -302,8 +315,13 @@ Filename changed to circumvent adblockers that mistake it for a crypto miner (se
         var unencrypted = document.getElementById('unencrypted_html').value,
             passphrase = document.getElementById('passphrase').value;
 
-        var encrypted = encrypt(unencrypted, passphrase),
-            hmac = CryptoJS.HmacSHA256(encrypted, CryptoJS.SHA256(passphrase).toString()).toString(),
+        var hashed = hashPassphrase(passphrase);
+        // we actually use the hashedPassphrase as the encryption passphrase
+        var hashedPassphrase = hashed.hashedPassphrase,
+            salt = hashed.salt;
+
+        var encrypted = encrypt(unencrypted, hashedPassphrase),
+            hmac = CryptoJS.HmacSHA256(encrypted, CryptoJS.SHA256(hashedPassphrase).toString()).toString(),
             encryptedMsg = hmac + encrypted;
 
         var decryptButton = document.getElementById('decrypt_button').value,
@@ -318,6 +336,7 @@ Filename changed to circumvent adblockers that mistake it for a crypto miner (se
             crypto_tag: '<script src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.9-1/crypto-js.min.js" integrity="sha384-lp4k1VRKPU9eBnPePjnJ9M2RF3i7PC30gXs70+elCVfgwLwx1tv5+ctxdtwxqZa7" crossorigin="anonymous"></scr' + 'ipt>',
             decrypt_button: decryptButton ? decryptButton : 'DECRYPT',
             encrypted: encryptedMsg,
+            salt: salt,
             instructions: instructions ? instructions : '',
             is_remember_enabled: isRememberEnabled ? 'true' : 'false',
             passphrase_placeholder: passphrasePlaceholder ? passphrasePlaceholder : 'Passphrase',

--- a/index.html
+++ b/index.html
@@ -26,10 +26,17 @@
     </style>
 
     <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+        (function (i, s, o, g, r, a, m) {
+            i['GoogleAnalyticsObject'] = r;
+            i[r] = i[r] || function () {
+                (i[r].q = i[r].q || []).push(arguments)
+            }, i[r].l = 1 * new Date();
+            a = s.createElement(o),
+                m = s.getElementsByTagName(o)[0];
+            a.async = 1;
+            a.src = g;
+            m.parentNode.insertBefore(a, m)
+        })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
 
         ga('create', 'UA-73629908-2', 'auto');
         ga('send', 'pageview');
@@ -65,7 +72,11 @@
             </p>
             <br>
 
-            <h4><a class="no-style" id="toggle-concept" href="#">HOW IT WORKS ►</a></h4>
+            <h4>
+                <a class="no-style" id="toggle-concept" href="#">
+                    <span id="toggle-concept-sign">►</span> HOW IT WORKS
+                </a>
+            </h4>
             <div id="concept" class="hidden">
                 <p>
                     <b class="text-danger">Disclaimer</b> if you have extra sensitive banking data, you should probably
@@ -98,11 +109,28 @@
                     <input type="password" class="form-control" id="passphrase"
                            placeholder="Passphrase (choose a long one!)">
                 </div>
+
                 <div class="form-group">
                     <label for="unencrypted_html">HTML/string to encrypt</label>
-                    <textarea class="form-control" id="unencrypted_html" placeholder="<html><head>..."
+                    <textarea class="form-control"
+                              id="unencrypted_html"
+                              placeholder="<html><head>..."
                               rows="5"></textarea>
                 </div>
+
+                <div class="form-group">
+                    <label class="no-style">
+                        <input type="checkbox" id="remember" checked>
+                        Add "Remember me" checkbox (append <code>?staticrypt_logout</code> to your URL to logout)
+                        <small>
+                            <abbr class="text-muted"
+                                  title="The password will be stored in clear text in the browser's localStorage upon entry by the user. See &quot;More options&quot; to set the expiration (default: none)">
+                                (?)
+                            </abbr>
+                        </small>
+                    </label>
+                </div>
+
                 <p>
                     <a href="#" id="toggle-extra-option">+ More options</a>
                 </p>
@@ -111,19 +139,50 @@
                         <label for="title">Page title</label>
                         <input type="text" class="form-control" id="title" placeholder="Default: 'Protected Page'">
                     </div>
+
                     <div class="form-group">
                         <label for="instructions">Instructions to display the user</label>
                         <textarea class="form-control" id="instructions" placeholder="Default: nothing."></textarea>
                     </div>
-                </div>
 
-                <div class="form-group">
-                    <label class="no-style">
-                        <input type="checkbox" id="embed-crypto" checked>
-                        Embed crypto-js into your file
-                        <abbr title="Leave checked to include crypto-js into your file so you can decrypt it offline.
-                        Uncheck to load crypto-js from a CDN (some adblockers might think it's a crypto miner).">?</abbr>
-                    </label>
+                    <div class="form-group">
+                        <label for="title">Passphrase input placeholder</label>
+                        <input type="text" class="form-control" id="passphrase_placeholder" placeholder="Default: 'Passphrase'">
+                    </div>
+
+                    <div class="form-group">
+                        <label for="title">"Remember me" checkbox label</label>
+                        <input type="text" class="form-control" id="remember_me" placeholder="Default: 'Remember me'">
+                    </div>
+
+                    <div class="form-group">
+                        <label for="title">"Remember me" expiration in days</label>
+                        <input type="number"
+                               class="form-control"
+                               id="remember_in_days"
+                               step="any"
+                               placeholder="Default: 0 (no expiration)">
+                        <small class="form-text text-muted">
+                            After this many days, the user will have to enter the passphrase again. Leave empty or set to 0 for no expiration.
+                        </small>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="title">Decrypt button label</label>
+                        <input type="text" class="form-control" id="decrypt_button" placeholder="Default: 'DECRYPT'">
+                    </div>
+
+                    <div class="form-group">
+                        <label class="no-style">
+                            <input type="checkbox" id="embed-crypto" checked>
+                            Embed crypto-js into your file
+                            <small>
+                                <abbr class="text-muted" title="Leave checked to include crypto-js into your file so you can decrypt it offline. Uncheck to load crypto-js from a CDN (some adblockers might think it's a crypto miner).">
+                                    (?)
+                                </abbr>
+                            </small>
+                        </label>
+                    </div>
                 </div>
 
                 <button class="btn btn-primary pull-right" type="submit">Generate passphrase protected HTML</button>
@@ -131,7 +190,7 @@
         </div>
     </div>
 
-    <div class="row">
+    <div class="row mb-5">
         <div class="col-xs-12">
             <h2>Encrypted HTML</h2>
             <p><a class="btn btn-success download"
@@ -155,7 +214,7 @@ Filename changed to circumvent adblockers that mistake it for a crypto miner (se
 
 <script>
     // enable CKEDIRTOR
-    CKEDITOR.replace( 'instructions' );
+    CKEDITOR.replace('instructions');
 
     var htmlToDownload;
 
@@ -172,7 +231,7 @@ Filename changed to circumvent adblockers that mistake it for a crypto miner (se
     var setFileToDownload = function (data) {
         var request = new XMLHttpRequest();
         request.open('GET', 'password_template.html', true);
-        request.onload = function() {
+        request.onload = function () {
             var renderedTmpl = renderTemplate(request.responseText, data);
 
             var downloadLink = document.querySelector('a.download');
@@ -191,7 +250,7 @@ Filename changed to circumvent adblockers that mistake it for a crypto miner (se
     var setFileToDownloadWithEmbeddedCrypto = function (data) {
         var request = new XMLHttpRequest();
         request.open('GET', 'kryptojs-3.1.9-1-lib.js', true);
-        request.onload = function() {
+        request.onload = function () {
             data['crypto_tag'] = '<script>' + request.responseText + '</scr' + 'ipt>';
             setFileToDownload(data);
         };
@@ -202,17 +261,18 @@ Filename changed to circumvent adblockers that mistake it for a crypto miner (se
      * Salt and encrypt a msg with a password.
      * Inspired by https://github.com/adonespitogo
      */
-    var keySize = 256;
-    var iterations = 1000;
-    function encrypt (msg, password) {
-        var salt = CryptoJS.lib.WordArray.random(128/8);
+    function encrypt(msg, password) {
+        var keySize = 256;
+        var iterations = 1000;
+
+        var salt = CryptoJS.lib.WordArray.random(128 / 8);
 
         var key = CryptoJS.PBKDF2(password, salt, {
-            keySize: keySize/32,
+            keySize: keySize / 32,
             iterations: iterations
         });
 
-        var iv = CryptoJS.lib.WordArray.random(128/8);
+        var iv = CryptoJS.lib.WordArray.random(128 / 8);
 
         var encrypted = CryptoJS.AES.encrypt(msg, key, {
             iv: iv,
@@ -222,8 +282,7 @@ Filename changed to circumvent adblockers that mistake it for a crypto miner (se
 
         // salt, iv will be hex 32 in length
         // append them to the ciphertext for use  in decryption
-        var encryptedMsg = salt.toString()+ iv.toString() + encrypted.toString();
-        return encryptedMsg;
+        return salt.toString() + iv.toString() + encrypted.toString();
     }
 
     /**
@@ -236,44 +295,60 @@ Filename changed to circumvent adblockers that mistake it for a crypto miner (se
         // (see https://stackoverflow.com/questions/3147670/ckeditor-update-textarea)
         CKEDITOR.instances['instructions'].updateElement();
 
-        var unencrypted = document.getElementById('unencrypted_html').value;
-        var passphrase = document.getElementById('passphrase').value;
+        var unencrypted = document.getElementById('unencrypted_html').value,
+            passphrase = document.getElementById('passphrase').value;
 
-        var encrypted = encrypt(unencrypted, passphrase);
-        var hmac = CryptoJS.HmacSHA256(encrypted, CryptoJS.SHA256(passphrase).toString()).toString();
-        var encryptedMsg = hmac + encrypted;
+        var encrypted = encrypt(unencrypted, passphrase),
+            hmac = CryptoJS.HmacSHA256(encrypted, CryptoJS.SHA256(passphrase).toString()).toString(),
+            encryptedMsg = hmac + encrypted;
 
-        var pageTitle = document.getElementById('title').value.trim();
-        var instructions = document.getElementById('instructions').value;
+        var decryptButton = document.getElementById('decrypt_button').value,
+            instructions = document.getElementById('instructions').value,
+            isRememberEnabled = document.getElementById('remember').checked,
+            pageTitle = document.getElementById('title').value.trim(),
+            passphrasePlaceholder = document.getElementById('passphrase_placeholder').value.trim(),
+            rememberDurationInDays = document.getElementById('remember_in_days').value || 0,
+            rememberMe = document.getElementById('remember_me').value;
+
         var data = {
-            title: pageTitle ? pageTitle : 'Protected Page',
-            instructions: instructions ? instructions : '',
+            crypto_tag: '<script src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.9-1/crypto-js.min.js" integrity="sha384-lp4k1VRKPU9eBnPePjnJ9M2RF3i7PC30gXs70+elCVfgwLwx1tv5+ctxdtwxqZa7" crossorigin="anonymous"></scr' + 'ipt>',
+            decrypt_button: decryptButton ? decryptButton : 'DECRYPT',
             encrypted: encryptedMsg,
-            crypto_tag: '<script src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.9-1/crypto-js.min.js" integrity="sha384-lp4k1VRKPU9eBnPePjnJ9M2RF3i7PC30gXs70+elCVfgwLwx1tv5+ctxdtwxqZa7" crossorigin="anonymous"></scr' + 'ipt>'
+            instructions: instructions ? instructions : '',
+            is_remember_enabled: isRememberEnabled ? 'true' : 'false',
+            passphrase_placeholder: passphrasePlaceholder ? passphrasePlaceholder : 'Passphrase',
+            remember_duration_in_days: rememberDurationInDays.toString(),
+            remember_me: rememberMe ? rememberMe : 'Remember me',
+            title: pageTitle ? pageTitle : 'Protected Page',
         };
 
         document.getElementById('encrypted_html_display').textContent = encryptedMsg;
 
         if (document.getElementById("embed-crypto").checked) {
             setFileToDownloadWithEmbeddedCrypto(data);
-        }
-        else {
+        } else {
             setFileToDownload(data);
         }
 
     });
 
     document.getElementById('toggle-extra-option')
-    .addEventListener('click', function (e) {
-        e.preventDefault();
-        document.getElementById('extra-options').classList.toggle('hidden');
-    });
+        .addEventListener('click', function (e) {
+            e.preventDefault();
+            document.getElementById('extra-options').classList.toggle('hidden');
+        });
 
+    var isConceptShown = false;
     document.getElementById('toggle-concept')
-    .addEventListener('click', function (e) {
-        e.preventDefault();
-        document.getElementById('concept').classList.toggle('hidden');
-    });
+        .addEventListener('click', function (e) {
+            e.preventDefault();
+
+            isConceptShown = !isConceptShown;
+
+            document.getElementById('toggle-concept-sign').innerText = isConceptShown ? '▼' : '►';
+
+            document.getElementById('concept').classList.toggle('hidden');
+        });
 
 
     /**
@@ -282,18 +357,18 @@ Filename changed to circumvent adblockers that mistake it for a crypto miner (se
     document.getElementById('download-link')
         .addEventListener('click', function (e) {
 
-        var isIE = (navigator.userAgent.indexOf("MSIE") !== -1 ) || (!!document.documentMode === true ); // >= 10
-        var isEdge = navigator.userAgent.indexOf("Edge") !== -1;
+            var isIE = (navigator.userAgent.indexOf("MSIE") !== -1) || (!!document.documentMode === true); // >= 10
+            var isEdge = navigator.userAgent.indexOf("Edge") !== -1;
 
-        // download with MS specific feature
-        if (htmlToDownload && (isIE || isEdge)) {
-            e.preventDefault();
-            var blobObject = new Blob([htmlToDownload]);
-            window.navigator.msSaveOrOpenBlob(blobObject, 'encrypted.html');
-        }
+            // download with MS specific feature
+            if (htmlToDownload && (isIE || isEdge)) {
+                e.preventDefault();
+                var blobObject = new Blob([htmlToDownload]);
+                window.navigator.msSaveOrOpenBlob(blobObject, 'encrypted.html');
+            }
 
-        return true;
-    })
+            return true;
+        })
 </script>
 
 

--- a/password_template.html
+++ b/password_template.html
@@ -38,7 +38,7 @@
             box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.2), 0 5px 5px 0 rgba(0, 0, 0, 0.24);
         }
 
-        .staticrypt-form input {
+        .staticrypt-form input[type="password"] {
             outline: 0;
             background: #f2f2f2;
             width: 100%;
@@ -110,6 +110,21 @@
         .staticrypt-footer a {
             text-decoration: none;
         }
+
+        label.staticrypt-remember {
+            display: flex;
+            align-items: center;
+            margin-bottom: 1em;
+        }
+
+        .staticrypt-remember input[type=checkbox] {
+            transform: scale(1.5);
+            margin-right: 1em;
+        }
+
+        .hidden {
+            display: none !important;
+        }
     </style>
 </head>
 
@@ -127,10 +142,17 @@
             <input id="staticrypt-password"
                    type="password"
                    name="password"
-                   placeholder="passphrase"
+                   placeholder="{passphrase_placeholder}"
                    autofocus/>
 
-            <input type="submit" class="staticrypt-decrypt-button" value="DECRYPT"/>
+            <label id="staticrypt-remember-label" class="staticrypt-remember hidden">
+                <input id="staticrypt-remember"
+                       type="checkbox"
+                       name="remember"/>
+                {remember_me}
+            </label>
+
+            <input type="submit" class="staticrypt-decrypt-button" value="{decrypt_button}"/>
         </form>
     </div>
 
@@ -143,49 +165,138 @@
 {crypto_tag}
 
 <script>
+    // variables to be filled when generating the file
+    var encryptedMsg = '{encrypted}',
+        isRememberEnabled = {is_remember_enabled},
+        rememberDurationInDays = {remember_duration_in_days}; // 0 means forever
+
+    // constants
+    var rememberPassphraseKey = 'staticrypt-passphrase',
+        rememberExpirationKey = 'staticrypt-expiration';
 
     /**
      * Decrypt a salted msg using a password.
      * Inspired by https://github.com/adonespitogo
+     *
+     * @param {string} encryptedMsg
+     * @param {string} pass
+     * @returns {string}
      */
-    var keySize = 256;
-    var iterations = 1000;
-    function decrypt (encryptedMsg, pass) {
+    function decryptMsg(encryptedMsg, pass) {
+        var keySize = 256;
+        var iterations = 1000;
+
         var salt = CryptoJS.enc.Hex.parse(encryptedMsg.substr(0, 32));
         var iv = CryptoJS.enc.Hex.parse(encryptedMsg.substr(32, 32))
         var encrypted = encryptedMsg.substring(64);
 
         var key = CryptoJS.PBKDF2(pass, salt, {
-            keySize: keySize/32,
+            keySize: keySize / 32,
             iterations: iterations
         });
 
-        var decrypted = CryptoJS.AES.decrypt(encrypted, key, {
+        return CryptoJS.AES.decrypt(encrypted, key, {
             iv: iv,
             padding: CryptoJS.pad.Pkcs7,
             mode: CryptoJS.mode.CBC
         }).toString(CryptoJS.enc.Utf8);
-        return decrypted;
     }
 
-    document.getElementById('staticrypt-form').addEventListener('submit', function(e) {
-        e.preventDefault();
-
-        var passphrase = document.getElementById('staticrypt-password').value,
-            encryptedMsg = '{encrypted}',
-            encryptedHMAC = encryptedMsg.substring(0, 64),
+    /**
+     * Decrypt our encrypted page, replace the whole HTML.
+     *
+     * @param passphrase
+     * @returns {boolean}
+     */
+    function decryptAndReplaceHtml(passphrase) {
+        var encryptedHMAC = encryptedMsg.substring(0, 64),
             encryptedHTML = encryptedMsg.substring(64),
             decryptedHMAC = CryptoJS.HmacSHA256(encryptedHTML, CryptoJS.SHA256(passphrase).toString()).toString();
 
         if (decryptedHMAC !== encryptedHMAC) {
-            alert('Bad passphrase!');
-            return;
+            return false;
         }
 
-        var plainHTML = decrypt(encryptedHTML, passphrase);
+        var plainHTML = decryptMsg(encryptedHTML, passphrase);
 
         document.write(plainHTML);
         document.close();
+
+        return true;
+    }
+
+    /**
+     * Clear localstorage from staticrypt related values
+     */
+    function clearLocalStorage() {
+        localStorage.removeItem(rememberPassphraseKey);
+        localStorage.removeItem(rememberExpirationKey);
+    }
+
+    // try to automatically decrypt on load if there is a saved password
+    window.onload = function () {
+        if (isRememberEnabled) {
+            // show the remember me checkbox
+            document.getElementById('staticrypt-remember-label').classList.remove('hidden');
+
+            // if we are login out, clear the storage and terminate
+            var queryParams = new URLSearchParams(window.location.search);
+
+            if (queryParams.has("staticrypt_logout")) {
+                return clearLocalStorage();
+            }
+
+            // if there is expiration configured, if we're not beyond the expiration
+            if (rememberDurationInDays && rememberDurationInDays > 0) {
+                var expiration = localStorage.getItem(rememberExpirationKey),
+                    isExpired = expiration && new Date().getTime() > parseInt(expiration);
+
+                if (isExpired) {
+                    return clearLocalStorage();
+                }
+            }
+
+            var passphrase = localStorage.getItem(rememberPassphraseKey);
+
+            if (passphrase) {
+                // try to decrypt
+                var isDecryptionSuccessful = decryptAndReplaceHtml(passphrase);
+
+                // if the decryption is unsuccessful the password might be wrong - silently clear the saved data and let
+                // the user fill the password form again
+                if (!isDecryptionSuccessful) {
+                    return clearLocalStorage();
+                }
+            }
+        }
+    }
+
+    // handle password form submission
+    document.getElementById('staticrypt-form').addEventListener('submit', function (e) {
+        e.preventDefault();
+
+        var passphrase = document.getElementById('staticrypt-password').value,
+            shouldRememberPassphrase = document.getElementById('staticrypt-remember').checked;
+
+        // decrypt and replace the whole page
+        var isDecryptionSuccessful = decryptAndReplaceHtml(passphrase);
+
+        if (isDecryptionSuccessful) {
+            // remember the passphrase and set its expiration if necessary
+            if (isRememberEnabled && shouldRememberPassphrase) {
+                window.localStorage.setItem(rememberPassphraseKey, passphrase);
+
+                // set the expiration if the duration isn't 0 (meaning no expiration)
+                if (rememberDurationInDays > 0) {
+                    window.localStorage.setItem(
+                        rememberExpirationKey,
+                        (new Date().getTime() + rememberDurationInDays * 24 * 60 * 60 * 1000).toString()
+                    );
+                }
+            }
+        } else {
+            alert('Bad passphrase!');
+        }
     });
 </script>
 </body>

--- a/password_template.html
+++ b/password_template.html
@@ -167,35 +167,27 @@
 <script>
     // variables to be filled when generating the file
     var encryptedMsg = '{encrypted}',
+        salt = '{salt}',
         isRememberEnabled = {is_remember_enabled},
         rememberDurationInDays = {remember_duration_in_days}; // 0 means forever
 
     // constants
-    var rememberPassphraseKey = 'staticrypt-passphrase',
-        rememberExpirationKey = 'staticrypt-expiration';
+    var rememberPassphraseKey = 'staticrypt_passphrase',
+        rememberExpirationKey = 'staticrypt_expiration';
 
     /**
      * Decrypt a salted msg using a password.
      * Inspired by https://github.com/adonespitogo
      *
      * @param {string} encryptedMsg
-     * @param {string} pass
+     * @param {string} hashedPassphrase
      * @returns {string}
      */
-    function decryptMsg(encryptedMsg, pass) {
-        var keySize = 256;
-        var iterations = 1000;
+    function decryptMsg(encryptedMsg, hashedPassphrase) {
+        var iv = CryptoJS.enc.Hex.parse(encryptedMsg.substr(0, 32))
+        var encrypted = encryptedMsg.substring(32);
 
-        var salt = CryptoJS.enc.Hex.parse(encryptedMsg.substr(0, 32));
-        var iv = CryptoJS.enc.Hex.parse(encryptedMsg.substr(32, 32))
-        var encrypted = encryptedMsg.substring(64);
-
-        var key = CryptoJS.PBKDF2(pass, salt, {
-            keySize: keySize / 32,
-            iterations: iterations
-        });
-
-        return CryptoJS.AES.decrypt(encrypted, key, {
+        return CryptoJS.AES.decrypt(encrypted, hashedPassphrase, {
             iv: iv,
             padding: CryptoJS.pad.Pkcs7,
             mode: CryptoJS.mode.CBC
@@ -205,24 +197,37 @@
     /**
      * Decrypt our encrypted page, replace the whole HTML.
      *
-     * @param passphrase
+     * @param {string} hashedPassphrase
      * @returns {boolean}
      */
-    function decryptAndReplaceHtml(passphrase) {
+    function decryptAndReplaceHtml(hashedPassphrase) {
         var encryptedHMAC = encryptedMsg.substring(0, 64),
             encryptedHTML = encryptedMsg.substring(64),
-            decryptedHMAC = CryptoJS.HmacSHA256(encryptedHTML, CryptoJS.SHA256(passphrase).toString()).toString();
+            decryptedHMAC = CryptoJS.HmacSHA256(encryptedHTML, CryptoJS.SHA256(hashedPassphrase).toString()).toString();
 
         if (decryptedHMAC !== encryptedHMAC) {
             return false;
         }
 
-        var plainHTML = decryptMsg(encryptedHTML, passphrase);
+        var plainHTML = decryptMsg(encryptedHTML, hashedPassphrase);
 
         document.write(plainHTML);
         document.close();
 
         return true;
+    }
+
+    /**
+     * Salt and hash the passphrase so it can be stored in localStorage without opening a password reuse vulnerability.
+     *
+     * @param {string} passphrase
+     * @returns {string}
+     */
+    function hashPassphrase(passphrase) {
+        return CryptoJS.PBKDF2(passphrase, salt, {
+            keySize: 256 / 32,
+            iterations: 1000
+        }).toString();
     }
 
     /**
@@ -246,7 +251,7 @@
                 return clearLocalStorage();
             }
 
-            // if there is expiration configured, if we're not beyond the expiration
+            // if there is expiration configured, check if we're not beyond the expiration
             if (rememberDurationInDays && rememberDurationInDays > 0) {
                 var expiration = localStorage.getItem(rememberExpirationKey),
                     isExpired = expiration && new Date().getTime() > parseInt(expiration);
@@ -256,11 +261,11 @@
                 }
             }
 
-            var passphrase = localStorage.getItem(rememberPassphraseKey);
+            var hashedPassphrase = localStorage.getItem(rememberPassphraseKey);
 
-            if (passphrase) {
+            if (hashedPassphrase) {
                 // try to decrypt
-                var isDecryptionSuccessful = decryptAndReplaceHtml(passphrase);
+                var isDecryptionSuccessful = decryptAndReplaceHtml(hashedPassphrase);
 
                 // if the decryption is unsuccessful the password might be wrong - silently clear the saved data and let
                 // the user fill the password form again
@@ -279,12 +284,13 @@
             shouldRememberPassphrase = document.getElementById('staticrypt-remember').checked;
 
         // decrypt and replace the whole page
-        var isDecryptionSuccessful = decryptAndReplaceHtml(passphrase);
+        var hashedPassphrase = hashPassphrase(passphrase);
+        var isDecryptionSuccessful = decryptAndReplaceHtml(hashedPassphrase);
 
         if (isDecryptionSuccessful) {
-            // remember the passphrase and set its expiration if necessary
+            // remember the hashedPassphrase and set its expiration if necessary
             if (isRememberEnabled && shouldRememberPassphrase) {
-                window.localStorage.setItem(rememberPassphraseKey, passphrase);
+                window.localStorage.setItem(rememberPassphraseKey, hashedPassphrase);
 
                 // set the expiration if the duration isn't 0 (meaning no expiration)
                 if (rememberDurationInDays > 0) {


### PR DESCRIPTION
Inspired by the discussion of #120 and #122 - this adds the option to put a "Remember me" checkbox on the decrypt screen.

When checked, when a user decrypts the page the passphrase will be saved in localStorage in plain text in the `staticrypt_passphrase` field and will automatically decrypt the page when they come back. 

If a non-zero expiration has been set when encrypting the page, another field `staticrypt_expiration` is created and saved in localStorage when the passphrase is successfully entered. If the user comes back to the page after this expiration date, both values are cleared from localStorage and the user has to enter their passphrase again.

It's also possible to clear the saved passphrase at anytime by appending `staticrypt_logout` to the URL query parameters.

---
The PR also adds more parameters to make all strings from the default password template editable (to help make i18n more accessible).

![Screenshot from 2022-02-09 11-42-59](https://user-images.githubusercontent.com/5664025/153182133-c368228b-c362-4e62-95aa-3773e38c6f47.png)

Closes #120, closes #114, closes #122