### PR TITLE
docs: add link to Github Pages template repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ StatiCrypt uses AES-256 to encrypt your HTML file with your passphrase and retur
 This means you can password protect the content of your static HTML file while still having the whole file completely public, without any back-end - serving it over Netlify, GitHub pages, etc.
 
 You can encrypt a file online in your browser (client side) at https://robinmoisson.github.io/staticrypt, or use the CLI to do it in your build process.
+If you want to host an encrypted single page website with Github Pages, you can find an easy-to-use template repository [here](https://github.com/a-nau/password-protected-website-template).
 
 ## HOW IT WORKS
 


### PR DESCRIPTION
Very cool work, thanks for that!

I created a [template repository](https://github.com/a-nau/password-protected-website-template) to easily host an encrypted website with Github Pages. I thought it might be an interesting pointer for people. If you think so too, feel free to merge this.

Cheers Alex