### PR TITLE
Dedupe source files

### DIFF
--- a/example/example_encrypted.html
+++ b/example/example_encrypted.html
@@ -165,8 +165,158 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.9-1/crypto-js.min.js" integrity="sha384-lp4k1VRKPU9eBnPePjnJ9M2RF3i7PC30gXs70+elCVfgwLwx1tv5+ctxdtwxqZa7" crossorigin="anonymous"></script>
 
 <script>
+    var impl = ((function(){
+  const exports = {};
+  
+/**
+ * Salt and encrypt a msg with a password.
+ * Inspired by https://github.com/adonespitogo
+ */
+function encrypt(msg, hashedPassphrase) {
+  var iv = CryptoJS.lib.WordArray.random(128 / 8);
+
+  var encrypted = CryptoJS.AES.encrypt(msg, hashedPassphrase, {
+    iv: iv,
+    padding: CryptoJS.pad.Pkcs7,
+    mode: CryptoJS.mode.CBC,
+  });
+
+  // iv will be hex 16 in length (32 characters)
+  // we prepend it to the ciphertext for use in decryption
+  return iv.toString() + encrypted.toString();
+}
+exports.encrypt = encrypt;
+
+/**
+ * Decrypt a salted msg using a password.
+ * Inspired by https://github.com/adonespitogo
+ *
+ * @param {string} encryptedMsg
+ * @param {string} hashedPassphrase
+ * @returns {string}
+ */
+function decrypt(encryptedMsg, hashedPassphrase) {
+  var iv = CryptoJS.enc.Hex.parse(encryptedMsg.substr(0, 32));
+  var encrypted = encryptedMsg.substring(32);
+
+  return CryptoJS.AES.decrypt(encrypted, hashedPassphrase, {
+    iv: iv,
+    padding: CryptoJS.pad.Pkcs7,
+    mode: CryptoJS.mode.CBC,
+  }).toString(CryptoJS.enc.Utf8);
+}
+exports.decrypt = decrypt;
+
+/**
+ * Salt and hash the passphrase so it can be stored in localStorage without opening a password reuse vulnerability.
+ *
+ * @param {string} passphrase
+ * @param {string} salt
+ * @returns string
+ */
+function hashPassphrase(passphrase, salt) {
+  var hashedPassphrase = CryptoJS.PBKDF2(passphrase, salt, {
+    keySize: 256 / 32,
+    iterations: 1000,
+  });
+
+  return hashedPassphrase.toString();
+}
+exports.hashPassphrase = hashPassphrase;
+
+function generateRandomSalt() {
+  return CryptoJS.lib.WordArray.random(128 / 8).toString();
+}
+exports.generateRandomSalt = generateRandomSalt;
+
+function signMessage(hashedPassphrase, message) {
+  return CryptoJS.HmacSHA256(
+    message,
+    CryptoJS.SHA256(hashedPassphrase).toString()
+  ).toString();
+}
+exports.signMessage = signMessage;
+
+  return exports;
+})())
+    var codec = ((function(){
+  const exports = {};
+  /**
+ * This file includes functions shared across all crytography implementations in lib/
+ * as well as cli and www clients.
+ */
+function init(impl) {
+  const exports = {};
+  /**
+   * Top-level function for encoding a message.
+   * Includes passphrase hashing, encryption, and signing.
+   *
+   * @param {string} msg
+   * @param {string} passphase
+   * @param {sting} salt
+   * @returns {string} The encoded text
+   */
+  function encode(msg, passphrase, salt) {
+    const hashedPassphrase = impl.hashPassphrase(passphrase, salt);
+    const encrypted = impl.encrypt(msg, hashedPassphrase);
+    // we use the hashed passphrase in the HMAC because this is effectively what will be used a passphrase (so we can store
+    // it in localStorage safely, we don't use the clear text passphrase)
+    const hmac = impl.signMessage(hashedPassphrase, encrypted);
+    return hmac + encrypted;
+  }
+  exports.encode = encode;
+
+  /**
+   * Top-level function for decoding a message.
+   * Includes signature check, an decryption.
+   *
+   * @param {*} encoded
+   * @param {*} hashedPassphrase
+   * @returns {Object} {success: true, decoded: string} | {succss: false, message: string}
+   */
+  function decode(signedMsg, hashedPassphrase) {
+    const encryptedHMAC = signedMsg.substring(0, 64);
+    const encryptedMsg = signedMsg.substring(64);
+    const decryptedHMAC = impl.signMessage(hashedPassphrase, encryptedMsg);
+
+    if (decryptedHMAC !== encryptedHMAC) {
+      return { success: false, message: "Signature mismatch" };
+    }
+    return {
+      success: true,
+      decoded: impl.decrypt(encryptedMsg, hashedPassphrase),
+    };
+  }
+  exports.decode = decode;
+
+  return exports;
+}
+exports.init = init;
+
+/**
+ * Replace the placeholder tags (between '{tag}') in 'tpl' string with provided data.
+ *
+ * @param tpl
+ * @param data
+ * @returns string
+ */
+function render(tpl, data) {
+  return tpl.replace(/{(.*?)}/g, function (_, key) {
+    if (data && data[key] !== undefined) {
+      return data[key];
+    }
+
+    return "";
+  });
+}
+exports.render = render;
+
+  return exports;
+})())
+    var decode = codec.init(impl).decode;
+
     // variables to be filled when generating the file
-    var encryptedMsg = '65a0577162396cc1bddae60b8f435291ff7a69644825b98bfc636a29089a28efbc9417689b983f2048bb776ca66eb25fU2FsdGVkX19n36H4ocM7GbaeFVganWX86ZTHEZk2w12z3z7rqWDW8OESK8MmGtbnPJetgyWi3jpz3iI+rE/gSilJkhQ2YR/4yCBintGLeh1hCgX+XPBEDT0w+ri4uqUWCxDUIvzyUhbnf1ZD2WsK9wmDHwRwF9YcucHXuyS7/GlUcVsYERzxxDd9frN6DbubNNbdY/QtG+vtmLSwHGZtwQ==',
+    var encryptedMsg = 'b95277ccf1e06625c90a837647563f9a11a5a47c3d861af72bebfc18a73c58f0922e1bd59a6f8a209711ea9852710f57U2FsdGVkX1+jQJWwwAq6XYWLTlrJL+U9JmFyiQ81/qIb44gnibQJ2SVzUbbCDlnAYxNoVm3ky2CoYGyrqTxBVWg550CATCFWGBpeFIMxIPj0IsN5MVHwhZO+DnerhHcV9OwEdryI7J43XQ1ZX8MjsS9/f04lt9pjrNmIw+8aksAys5oQ7Uv65iJdbiHJCHrzLckfM4Al01053nA0RyfcNQ==',
         salt = 'b93bbaf35459951c47721d1f3eaeb5b9',
         isRememberEnabled = true,
         rememberDurationInDays = 0; // 0 means forever
@@ -176,58 +326,21 @@
         rememberExpirationKey = 'staticrypt_expiration';
 
     /**
-     * Decrypt a salted msg using a password.
-     * Inspired by https://github.com/adonespitogo
-     *
-     * @param  encryptedMsg
-     * @param  hashedPassphrase
-     * @returns 
-     */
-    function decryptMsg(encryptedMsg, hashedPassphrase) {
-        var iv = CryptoJS.enc.Hex.parse(encryptedMsg.substr(0, 32))
-        var encrypted = encryptedMsg.substring(32);
-
-        return CryptoJS.AES.decrypt(encrypted, hashedPassphrase, {
-            iv: iv,
-            padding: CryptoJS.pad.Pkcs7,
-            mode: CryptoJS.mode.CBC
-        }).toString(CryptoJS.enc.Utf8);
-    }
-
-    /**
      * Decrypt our encrypted page, replace the whole HTML.
      *
      * @param  hashedPassphrase
      * @returns 
      */
     function decryptAndReplaceHtml(hashedPassphrase) {
-        var encryptedHMAC = encryptedMsg.substring(0, 64),
-            encryptedHTML = encryptedMsg.substring(64),
-            decryptedHMAC = CryptoJS.HmacSHA256(encryptedHTML, CryptoJS.SHA256(hashedPassphrase).toString()).toString();
-
-        if (decryptedHMAC !== encryptedHMAC) {
+        var result = decode(encryptedMsg, hashedPassphrase);
+        if (!result.success) {
             return false;
         }
-
-        var plainHTML = decryptMsg(encryptedHTML, hashedPassphrase);
+        var plainHTML = result.decoded;
 
         document.write(plainHTML);
         document.close();
-
         return true;
-    }
-
-    /**
-     * Salt and hash the passphrase so it can be stored in localStorage without opening a password reuse vulnerability.
-     *
-     * @param  passphrase
-     * @returns 
-     */
-    function hashPassphrase(passphrase) {
-        return CryptoJS.PBKDF2(passphrase, salt, {
-            keySize: 256 / 32,
-            iterations: 1000
-        }).toString();
     }
 
     /**
@@ -284,7 +397,7 @@
             shouldRememberPassphrase = document.getElementById('staticrypt-remember').checked;
 
         // decrypt and replace the whole page
-        var hashedPassphrase = hashPassphrase(passphrase);
+        var hashedPassphrase = impl.hashPassphrase(passphrase, salt);
         var isDecryptionSuccessful = decryptAndReplaceHtml(hashedPassphrase);
 
         if (isDecryptionSuccessful) {

--- a/lib/codec.js
+++ b/lib/codec.js
@@ -1,0 +1,69 @@
+/**
+ * This file includes functions shared across all crytography implementations in lib/
+ * as well as cli and www clients.
+ */
+function init(impl) {
+  const exports = {};
+  /**
+   * Top-level function for encoding a message.
+   * Includes passphrase hashing, encryption, and signing.
+   *
+   * @param {string} msg
+   * @param {string} passphase
+   * @param {sting} salt
+   * @returns {string} The encoded text
+   */
+  function encode(msg, passphrase, salt) {
+    const hashedPassphrase = impl.hashPassphrase(passphrase, salt);
+    const encrypted = impl.encrypt(msg, hashedPassphrase);
+    // we use the hashed passphrase in the HMAC because this is effectively what will be used a passphrase (so we can store
+    // it in localStorage safely, we don't use the clear text passphrase)
+    const hmac = impl.signMessage(hashedPassphrase, encrypted);
+    return hmac + encrypted;
+  }
+  exports.encode = encode;
+
+  /**
+   * Top-level function for decoding a message.
+   * Includes signature check, an decryption.
+   *
+   * @param {*} encoded
+   * @param {*} hashedPassphrase
+   * @returns {Object} {success: true, decoded: string} | {succss: false, message: string}
+   */
+  function decode(signedMsg, hashedPassphrase) {
+    const encryptedHMAC = signedMsg.substring(0, 64);
+    const encryptedMsg = signedMsg.substring(64);
+    const decryptedHMAC = impl.signMessage(hashedPassphrase, encryptedMsg);
+
+    if (decryptedHMAC !== encryptedHMAC) {
+      return { success: false, message: "Signature mismatch" };
+    }
+    return {
+      success: true,
+      decoded: impl.decrypt(encryptedMsg, hashedPassphrase),
+    };
+  }
+  exports.decode = decode;
+
+  return exports;
+}
+exports.init = init;
+
+/**
+ * Replace the placeholder tags (between '{tag}') in 'tpl' string with provided data.
+ *
+ * @param tpl
+ * @param data
+ * @returns string
+ */
+function render(tpl, data) {
+  return tpl.replace(/{(.*?)}/g, function (_, key) {
+    if (data && data[key] !== undefined) {
+      return data[key];
+    }
+
+    return "";
+  });
+}
+exports.render = render;

--- a/lib/impl-cryptojs.js
+++ b/lib/impl-cryptojs.js
@@ -1,0 +1,70 @@
+const CryptoJS = require("crypto-js");
+
+/**
+ * Salt and encrypt a msg with a password.
+ * Inspired by https://github.com/adonespitogo
+ */
+function encrypt(msg, hashedPassphrase) {
+  var iv = CryptoJS.lib.WordArray.random(128 / 8);
+
+  var encrypted = CryptoJS.AES.encrypt(msg, hashedPassphrase, {
+    iv: iv,
+    padding: CryptoJS.pad.Pkcs7,
+    mode: CryptoJS.mode.CBC,
+  });
+
+  // iv will be hex 16 in length (32 characters)
+  // we prepend it to the ciphertext for use in decryption
+  return iv.toString() + encrypted.toString();
+}
+exports.encrypt = encrypt;
+
+/**
+ * Decrypt a salted msg using a password.
+ * Inspired by https://github.com/adonespitogo
+ *
+ * @param {string} encryptedMsg
+ * @param {string} hashedPassphrase
+ * @returns {string}
+ */
+function decrypt(encryptedMsg, hashedPassphrase) {
+  var iv = CryptoJS.enc.Hex.parse(encryptedMsg.substr(0, 32));
+  var encrypted = encryptedMsg.substring(32);
+
+  return CryptoJS.AES.decrypt(encrypted, hashedPassphrase, {
+    iv: iv,
+    padding: CryptoJS.pad.Pkcs7,
+    mode: CryptoJS.mode.CBC,
+  }).toString(CryptoJS.enc.Utf8);
+}
+exports.decrypt = decrypt;
+
+/**
+ * Salt and hash the passphrase so it can be stored in localStorage without opening a password reuse vulnerability.
+ *
+ * @param {string} passphrase
+ * @param {string} salt
+ * @returns string
+ */
+function hashPassphrase(passphrase, salt) {
+  var hashedPassphrase = CryptoJS.PBKDF2(passphrase, salt, {
+    keySize: 256 / 32,
+    iterations: 1000,
+  });
+
+  return hashedPassphrase.toString();
+}
+exports.hashPassphrase = hashPassphrase;
+
+function generateRandomSalt() {
+  return CryptoJS.lib.WordArray.random(128 / 8).toString();
+}
+exports.generateRandomSalt = generateRandomSalt;
+
+function signMessage(hashedPassphrase, message) {
+  return CryptoJS.HmacSHA256(
+    message,
+    CryptoJS.SHA256(hashedPassphrase).toString()
+  ).toString();
+}
+exports.signMessage = signMessage;

--- a/lib/index_template.html
+++ b/lib/index_template.html
@@ -215,157 +215,11 @@ Filename changed to circumvent adblockers that mistake it for a crypto miner (se
 <script src="https://cdn.ckeditor.com/4.7.0/standard/ckeditor.js"></script>
 
 <script id="impl">
-    window.impl = ((function(){
-  const exports = {};
-  
-/**
- * Salt and encrypt a msg with a password.
- * Inspired by https://github.com/adonespitogo
- */
-function encrypt(msg, hashedPassphrase) {
-  var iv = CryptoJS.lib.WordArray.random(128 / 8);
-
-  var encrypted = CryptoJS.AES.encrypt(msg, hashedPassphrase, {
-    iv: iv,
-    padding: CryptoJS.pad.Pkcs7,
-    mode: CryptoJS.mode.CBC,
-  });
-
-  // iv will be hex 16 in length (32 characters)
-  // we prepend it to the ciphertext for use in decryption
-  return iv.toString() + encrypted.toString();
-}
-exports.encrypt = encrypt;
-
-/**
- * Decrypt a salted msg using a password.
- * Inspired by https://github.com/adonespitogo
- *
- * @param {string} encryptedMsg
- * @param {string} hashedPassphrase
- * @returns {string}
- */
-function decrypt(encryptedMsg, hashedPassphrase) {
-  var iv = CryptoJS.enc.Hex.parse(encryptedMsg.substr(0, 32));
-  var encrypted = encryptedMsg.substring(32);
-
-  return CryptoJS.AES.decrypt(encrypted, hashedPassphrase, {
-    iv: iv,
-    padding: CryptoJS.pad.Pkcs7,
-    mode: CryptoJS.mode.CBC,
-  }).toString(CryptoJS.enc.Utf8);
-}
-exports.decrypt = decrypt;
-
-/**
- * Salt and hash the passphrase so it can be stored in localStorage without opening a password reuse vulnerability.
- *
- * @param {string} passphrase
- * @param {string} salt
- * @returns string
- */
-function hashPassphrase(passphrase, salt) {
-  var hashedPassphrase = CryptoJS.PBKDF2(passphrase, salt, {
-    keySize: 256 / 32,
-    iterations: 1000,
-  });
-
-  return hashedPassphrase.toString();
-}
-exports.hashPassphrase = hashPassphrase;
-
-function generateRandomSalt() {
-  return CryptoJS.lib.WordArray.random(128 / 8).toString();
-}
-exports.generateRandomSalt = generateRandomSalt;
-
-function signMessage(hashedPassphrase, message) {
-  return CryptoJS.HmacSHA256(
-    message,
-    CryptoJS.SHA256(hashedPassphrase).toString()
-  ).toString();
-}
-exports.signMessage = signMessage;
-
-  return exports;
-})())
+    window.impl = {impl_iif}
 </script>
 
 <script id="codec">
-    window.codec = ((function(){
-  const exports = {};
-  /**
- * This file includes functions shared across all crytography implementations in lib/
- * as well as cli and www clients.
- */
-function init(impl) {
-  const exports = {};
-  /**
-   * Top-level function for encoding a message.
-   * Includes passphrase hashing, encryption, and signing.
-   *
-   * @param {string} msg
-   * @param {string} passphase
-   * @param {sting} salt
-   * @returns {string} The encoded text
-   */
-  function encode(msg, passphrase, salt) {
-    const hashedPassphrase = impl.hashPassphrase(passphrase, salt);
-    const encrypted = impl.encrypt(msg, hashedPassphrase);
-    // we use the hashed passphrase in the HMAC because this is effectively what will be used a passphrase (so we can store
-    // it in localStorage safely, we don't use the clear text passphrase)
-    const hmac = impl.signMessage(hashedPassphrase, encrypted);
-    return hmac + encrypted;
-  }
-  exports.encode = encode;
-
-  /**
-   * Top-level function for decoding a message.
-   * Includes signature check, an decryption.
-   *
-   * @param {*} encoded
-   * @param {*} hashedPassphrase
-   * @returns {Object} {success: true, decoded: string} | {succss: false, message: string}
-   */
-  function decode(signedMsg, hashedPassphrase) {
-    const encryptedHMAC = signedMsg.substring(0, 64);
-    const encryptedMsg = signedMsg.substring(64);
-    const decryptedHMAC = impl.signMessage(hashedPassphrase, encryptedMsg);
-
-    if (decryptedHMAC !== encryptedHMAC) {
-      return { success: false, message: "Signature mismatch" };
-    }
-    return {
-      success: true,
-      decoded: impl.decrypt(encryptedMsg, hashedPassphrase),
-    };
-  }
-  exports.decode = decode;
-
-  return exports;
-}
-exports.init = init;
-
-/**
- * Replace the placeholder tags (between '{tag}') in 'tpl' string with provided data.
- *
- * @param tpl
- * @param data
- * @returns string
- */
-function render(tpl, data) {
-  return tpl.replace(/{(.*?)}/g, function (_, key) {
-    if (data && data[key] !== undefined) {
-      return data[key];
-    }
-
-    return "";
-  });
-}
-exports.render = render;
-
-  return exports;
-})())
+    window.codec = {codec_iif}
 </script>
 
 <script>
@@ -435,8 +289,8 @@ exports.render = render;
     /**
      * Salt and hash the passphrase so it can be stored in localStorage without opening a password reuse vulnerability.
      *
-     * @param  passphrase
-     * @returns }
+     * @param {string} passphrase
+     * @returns {{salt: string, hashedPassphrase: string}}
      */
     function hashPassphrase(passphrase) {
         var salt = CryptoJS.lib.WordArray.random(128 / 8).toString();

--- a/lib/password_template.html
+++ b/lib/password_template.html
@@ -165,6 +165,10 @@
 {crypto_tag}
 
 <script>
+    var impl = {impl_iif}
+    var codec = {codec_iif}
+    var decode = codec.init(impl).decode;
+
     // variables to be filled when generating the file
     var encryptedMsg = '{encrypted}',
         salt = '{salt}',
@@ -176,58 +180,21 @@
         rememberExpirationKey = 'staticrypt_expiration';
 
     /**
-     * Decrypt a salted msg using a password.
-     * Inspired by https://github.com/adonespitogo
-     *
-     * @param {string} encryptedMsg
-     * @param {string} hashedPassphrase
-     * @returns {string}
-     */
-    function decryptMsg(encryptedMsg, hashedPassphrase) {
-        var iv = CryptoJS.enc.Hex.parse(encryptedMsg.substr(0, 32))
-        var encrypted = encryptedMsg.substring(32);
-
-        return CryptoJS.AES.decrypt(encrypted, hashedPassphrase, {
-            iv: iv,
-            padding: CryptoJS.pad.Pkcs7,
-            mode: CryptoJS.mode.CBC
-        }).toString(CryptoJS.enc.Utf8);
-    }
-
-    /**
      * Decrypt our encrypted page, replace the whole HTML.
      *
      * @param {string} hashedPassphrase
      * @returns {boolean}
      */
     function decryptAndReplaceHtml(hashedPassphrase) {
-        var encryptedHMAC = encryptedMsg.substring(0, 64),
-            encryptedHTML = encryptedMsg.substring(64),
-            decryptedHMAC = CryptoJS.HmacSHA256(encryptedHTML, CryptoJS.SHA256(hashedPassphrase).toString()).toString();
-
-        if (decryptedHMAC !== encryptedHMAC) {
+        var result = decode(encryptedMsg, hashedPassphrase);
+        if (!result.success) {
             return false;
         }
-
-        var plainHTML = decryptMsg(encryptedHTML, hashedPassphrase);
+        var plainHTML = result.decoded;
 
         document.write(plainHTML);
         document.close();
-
         return true;
-    }
-
-    /**
-     * Salt and hash the passphrase so it can be stored in localStorage without opening a password reuse vulnerability.
-     *
-     * @param {string} passphrase
-     * @returns {string}
-     */
-    function hashPassphrase(passphrase) {
-        return CryptoJS.PBKDF2(passphrase, salt, {
-            keySize: 256 / 32,
-            iterations: 1000
-        }).toString();
     }
 
     /**
@@ -284,7 +251,7 @@
             shouldRememberPassphrase = document.getElementById('staticrypt-remember').checked;
 
         // decrypt and replace the whole page
-        var hashedPassphrase = hashPassphrase(passphrase);
+        var hashedPassphrase = impl.hashPassphrase(passphrase, salt);
         var isDecryptionSuccessful = decryptAndReplaceHtml(hashedPassphrase);
 
         if (isDecryptionSuccessful) {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,8 +1,21 @@
 # Usage: `npm run build`
 # NPM establishes a reliable working directory
 
-# Encrypt the example file
+#
+# Example
+#
 npx . example/example.html test \
     --no-embed \
     --salt b93bbaf35459951c47721d1f3eaeb5b9 \
     --instructions "Enter \"test\" to unlock the page"
+
+#
+# WWW
+#
+# Inline www dependencies using staticrypt's internal template expansion.
+# Input file and salt are unused, but required.
+npx . example/example.html test \
+    --no-embed \
+    --file-template lib/index_template.html \
+    --output index.html \
+    --salt b93bbaf35459951c47721d1f3eaeb5b9 \


### PR DESCRIPTION
Depends on #137 

This diff tackles point 2 from #137 - lots of crypto code is duplicated.

This problem seems worth solving both to make sure the crypto functions evolve consistently, and to reduce merge and rebase pain for contributors.

See `transcludeModule` for the crux of this diff. We use a very simple CommonJS -> browser transform to share some pure functions between the node CLI and browser.

The extra separation between `codec.js` and `impl-cryptojs.js` paves the way for easily switching between CryptoJS and WebCrypto.