### PR TITLE
Fix encryption not happening when `--share` present

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -88,7 +88,6 @@ async function runStatiCrypt() {
         const url = namedArgs.share || "";
 
         console.log(url + "#staticrypt_pwd=" + hashedPassword);
-        return;
     }
 
     // only process a directory if the --recursive flag is set


### PR DESCRIPTION
Hi and congrats on making this great tool!

According to the [documentation](https://github.com/robinmoisson/staticrypt#cli), the command `staticrypt test.html --share` should _Encrypt a file and get a shareable link containing the hashed password_.

However, only the shareable link was displayed, the encryption wasn't happening because of an early `return`.

This PR fixes this.