### PR TITLE
Add remember me param to shareable link

### DIFF
--- a/lib/staticryptJs.js
+++ b/lib/staticryptJs.js
@@ -63,11 +63,17 @@ function init(staticryptConfig, templateConfig) {
      *   expose more information in the future we can do it without breaking the password_template
      */
     async function handleDecryptionOfPage(password, isRememberChecked) {
-        const { isRememberEnabled, rememberDurationInDays, staticryptSaltUniqueVariableName } = staticryptConfig;
-        const { rememberExpirationKey, rememberPassphraseKey } = templateConfig;
+        const { staticryptSaltUniqueVariableName } = staticryptConfig;
 
         // decrypt and replace the whole page
         const hashedPassword = await cryptoEngine.hashPassword(password, staticryptSaltUniqueVariableName);
+        return handleDecryptionOfPageAndRemember(hashedPassword, isRememberChecked)
+    }
+    exports.handleDecryptionOfPage = handleDecryptionOfPage;
+
+    async function handleDecryptionOfPageAndRemember(hashedPassword, isRememberChecked) {
+        const { isRememberEnabled, rememberDurationInDays } = staticryptConfig;
+        const { rememberExpirationKey, rememberPassphraseKey } = templateConfig;
 
         const isDecryptionSuccessful = await decryptAndReplaceHtml(hashedPassword);
 
@@ -96,7 +102,6 @@ function init(staticryptConfig, templateConfig) {
             hashedPassword,
         };
     }
-    exports.handleDecryptionOfPage = handleDecryptionOfPage;
 
     /**
      * Clear localstorage from staticrypt related values
@@ -195,10 +200,12 @@ function init(staticryptConfig, templateConfig) {
 
     function decryptOnLoadFromUrl() {
         const passwordKey = "staticrypt_pwd";
+        const rememberMeKey = "remember_me";
 
         // get the password from the query param
         const queryParams = new URLSearchParams(window.location.search);
         const hashedPasswordQuery = queryParams.get(passwordKey);
+        const rememberMeQuery = queryParams.get(rememberMeKey);
 
         // get the password from the url fragment
         const hashRegexMatch = window.location.hash.substring(1).match(new RegExp(passwordKey + "=(.*)"));
@@ -207,7 +214,8 @@ function init(staticryptConfig, templateConfig) {
         const hashedPassword = hashedPasswordFragment || hashedPasswordQuery;
 
         if (hashedPassword) {
-            return decryptAndReplaceHtml(hashedPassword);
+            //return decryptAndReplaceHtml(hashedPassword);
+            return handleDecryptionOfPageAndRemember(hashedPassword, rememberMeQuery);
         }
 
         return false;


### PR DESCRIPTION
# Summary
In our use case we would like to send the clients the "ugly" shareable link once, and from there on we want them to easily go straight to the website without needing the original link or even to be aware that the site is protected.

So, adding a `remember_me=1` query param should be a nice way to achieve that.

what do you think?

related to: #183