### PR TITLE
Add option to have Remember Me chedked by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The password argument is optional if `STATICRYPT_PASSWORD` is set in the environ
           --template-remember         Label to use for the "Remember me" checkbox.
                                                    [string] [default: "Remember me"]
           --template-remember-checked Makes the "Remember me" checkbox checked by default. 
-                                                   [string] [default: "Remember me"]
+                                                   [boolean]: false
           --template-title            Title for the output HTML page.
                                                 [string] [default: "Protected Page"]
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ The password argument is optional if `STATICRYPT_PASSWORD` is set in the environ
                                                       [string] [default: "Password"]
           --template-remember         Label to use for the "Remember me" checkbox.
                                                    [string] [default: "Remember me"]
+          --template-remember-checked Makes the "Remember me" checkbox checked by default. 
+                                                   [string] [default: "Remember me"]
           --template-title            Title for the output HTML page.
                                                 [string] [default: "Protected Page"]
 

--- a/cli/helpers.js
+++ b/cli/helpers.js
@@ -472,6 +472,11 @@ function parseCommandLineArguments() {
                 describe: 'Label to use for the "Remember me" checkbox.',
                 default: "Remember me",
             })
+            .option("template-remember-checked", {
+                type: "boolean",
+                describe: 'Label to use for the "Remember me" checkbox.',
+                default: false,
+            })
             .option("template-title", {
                 type: "string",
                 describe: "Title for the output HTML page.",

--- a/cli/index.js
+++ b/cli/index.js
@@ -137,6 +137,7 @@ async function runStatiCrypt() {
         template_instructions: namedArgs.templateInstructions,
         template_placeholder: namedArgs.templatePlaceholder,
         template_remember: namedArgs.templateRemember,
+        template_remember_checked: namedArgs.templateRememberChecked ? "checked" : "",
         template_title: namedArgs.templateTitle,
         template_color_primary: namedArgs.templateColorPrimary,
         template_color_secondary: namedArgs.templateColorSecondary,

--- a/lib/password_template.html
+++ b/lib/password_template.html
@@ -170,7 +170,7 @@
                         />
 
                         <label id="staticrypt-remember-label" class="staticrypt-remember hidden">
-                            <input id="staticrypt-remember" type="checkbox" name="remember" />
+                            <input id="staticrypt-remember" type="checkbox" name="remember" /*[|template_remember_checked|]*/0 />
                             /*[|template_remember|]*/0
                         </label>
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -11,5 +11,6 @@ node ../cli/index.js example.html \
     --short \
     --salt b93bbaf35459951c47721d1f3eaeb5b9 \
     --config false \
-    --template-instructions "Enter \"test\" to unlock the page"
+    --template-instructions "Enter \"test\" to unlock the page" \
+    --template-remember-checked
 


### PR DESCRIPTION
This introduces a `--template-remember-checked` option that allows the "Remember me" checkbox to be toggled on by default.
