### PR TITLE
Add --overwrite flag to staticrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ staticrypt dir_to_encrypt/* -r
 staticrypt dir_to_encrypt/* -r -d dir_to_encrypt
 ```
 
+#### Overwrite files in-place
+
+```bash
+# Use the --overwrite flag to overwrite the original files in-place
+staticrypt dir_to_encrypt/* -r --overwrite
+```
+
 #### Get a shareable auto-decrypt link
 
 The link contains the hashed password, that will auto-decrypt the file - you can include your file URL or leave blank. (⚠️ you should keep your `.staticrypt.json` so the salt is the same each time you encrypt, or re-encrypting will [invalidate the link](#why-does-staticrypt-create-a-config-file)): 
@@ -153,6 +160,8 @@ The password argument is optional if `STATICRYPT_PASSWORD` is set in the environ
                                                      [string] [default: "encrypted"]
           --decrypt                   Include this flag to decrypt files instead of
                                       encrypt.            [boolean] [default: false]
+          --overwrite                 Overwrite the original files in-place.
+                                                          [boolean] [default: false]
       -p, --password                  The password to encrypt your file with. Leave
                                       empty to be prompted for it. If
                                       STATICRYPT_PASSWORD is set in the env, we'll

--- a/cli/helpers.js
+++ b/cli/helpers.js
@@ -274,9 +274,13 @@ exports.genFile = genFile;
  * @param {string} path
  * @param {string} fullRootDirectory
  * @param {string} outputDirectory
+ * @param {boolean} overwrite
  * @returns {string}
  */
-function getFullOutputPath(path, fullRootDirectory, outputDirectory) {
+function getFullOutputPath(path, fullRootDirectory, outputDirectory, overwrite) {
+    if (overwrite) {
+        return path;
+    }
     const relativePath = pathModule.relative(fullRootDirectory, path);
     return outputDirectory + "/" + relativePath;
 }
@@ -339,9 +343,10 @@ exports.isCustomPasswordTemplateDefault = isCustomPasswordTemplateDefault;
  * @param {string} path
  * @param {string} outputDirectory
  * @param {string} rootDirectory
+ * @param {boolean} overwrite
  * @param {(fullPath: string, rootDirectoryFromArgument: string) => void} callback
  */
-function recursivelyApplyCallbackToHtmlFiles(callback, path, outputDirectory, rootDirectory = "") {
+function recursivelyApplyCallbackToHtmlFiles(callback, path, outputDirectory, rootDirectory = "", overwrite = false) {
     const fullPath = pathModule.resolve(path);
     const fullRootDirectory = rootDirectory || pathModule.dirname(fullPath);
 
@@ -349,7 +354,7 @@ function recursivelyApplyCallbackToHtmlFiles(callback, path, outputDirectory, ro
         fs.readdirSync(fullPath).forEach((filePath) => {
             const fullFilePath = `${fullPath}/${filePath}`;
 
-            recursivelyApplyCallbackToHtmlFiles(callback, fullFilePath, outputDirectory, fullRootDirectory);
+            recursivelyApplyCallbackToHtmlFiles(callback, fullFilePath, outputDirectory, fullRootDirectory, overwrite);
         });
         return;
     }
@@ -360,7 +365,7 @@ function recursivelyApplyCallbackToHtmlFiles(callback, path, outputDirectory, ro
     }
     // else just copy the file as is
     else {
-        const fullOutputPath = getFullOutputPath(fullPath, fullRootDirectory, outputDirectory);
+        const fullOutputPath = getFullOutputPath(fullPath, fullRootDirectory, outputDirectory, overwrite);
         copyFile(fullPath, fullOutputPath);
     }
 }
@@ -386,6 +391,11 @@ function parseCommandLineArguments() {
             .option("decrypt", {
                 type: "boolean",
                 describe: "Include this flag to decrypt files instead of encrypt.",
+                default: false,
+            })
+            .option("overwrite", {
+                type: "boolean",
+                describe: "Overwrite the original files in-place.",
                 default: false,
             })
             .option("p", {

--- a/cli/index.js
+++ b/cli/index.js
@@ -164,7 +164,9 @@ async function runStatiCrypt() {
                 );
             },
             path,
-            namedArgs.directory
+            namedArgs.directory,
+            "",
+            namedArgs.overwrite
         );
     });
 }
@@ -223,8 +225,7 @@ async function encodeAndGenerateFile(
     };
 
     // remove the base path so that the actual output path is relative to the base path
-    const relativePath = pathModule.relative(rootDirectoryFromArguments, path);
-    const outputFilepath = namedArgs.directory + "/" + relativePath;
+    const outputFilepath = getFullOutputPath(path, rootDirectoryFromArguments, namedArgs.directory, namedArgs.overwrite);
 
     genFile(templateData, outputFilepath, namedArgs.template);
 }


### PR DESCRIPTION
Fixes #196

Add support for the `--overwrite` flag to overwrite files in-place.

* **cli/helpers.js**
  - Add `overwrite` parameter to `getFullOutputPath` and `recursivelyApplyCallbackToHtmlFiles` functions.
  - Update `parseCommandLineArguments` to include the `--overwrite` option.

* **cli/index.js**
  - Update `runStatiCrypt` function to handle the `--overwrite` flag.
  - Update `encodeAndGenerateFile` function to handle the `--overwrite` flag.

* **README.md**
  - Add documentation for the `--overwrite` flag in the CLI section.
  - Add an example of using the `--overwrite` flag.