### PR TITLE
Fixes template variable formatting in password_template.html

### DIFF
--- a/lib/password_template.html
+++ b/lib/password_template.html
@@ -74,7 +74,7 @@
             .staticrypt-form .staticrypt-decrypt-button {
                 text-transform: uppercase;
                 outline: 0;
-                background: /*[|template_color_primary|]*/ 0;
+                background: /*[|template_color_primary|]*/0;
                 width: 100%;
                 border: 0;
                 padding: 15px;
@@ -86,7 +86,7 @@
             .staticrypt-form .staticrypt-decrypt-button:hover,
             .staticrypt-form .staticrypt-decrypt-button:active,
             .staticrypt-form .staticrypt-decrypt-button:focus {
-                background: /*[|template_color_primary|]*/ 0;
+                background: /*[|template_color_primary|]*/0;
                 filter: brightness(92%);
             }
 
@@ -102,7 +102,7 @@
             .staticrypt-content {
                 height: 100%;
                 margin-bottom: 1em;
-                background: /*[|template_color_secondary|]*/ 0;
+                background: /*[|template_color_secondary|]*/0;
                 font-family: "Arial", sans-serif;
                 -webkit-font-smoothing: antialiased;
                 -moz-osx-font-smoothing: grayscale;
@@ -213,12 +213,12 @@
 
         <script>
             // these variables will be filled when generating the file - the template format is '/*[|variable_name|]*/0'
-            const staticryptInitiator = /*[|js_staticrypt|]*/ 0;
+            const staticryptInitiator = /*[|js_staticrypt|]*/0;
             const templateError = "/*[|template_error|]*/0",
                 templateToggleAltShow = "/*[|template_toggle_show|]*/0",
                 templateToggleAltHide = "/*[|template_toggle_hide|]*/0",
-                isRememberEnabled = /*[|is_remember_enabled|]*/ 0,
-                staticryptConfig = /*[|staticrypt_config|]*/ 0;
+                isRememberEnabled = /*[|is_remember_enabled|]*/0,
+                staticryptConfig = /*[|staticrypt_config|]*/0;
 
             // you can edit these values to customize some of the behavior of StatiCrypt
             const templateConfig = {


### PR DESCRIPTION
All template variables outside a string or HTML tag contained a space before the 0 char, likely applied by a code formatter.